### PR TITLE
fix: add missing track_locks migration and fix session poisoning

### DIFF
--- a/migrations/versions/e5f6a7b8c9d0_add_track_locks_table.py
+++ b/migrations/versions/e5f6a7b8c9d0_add_track_locks_table.py
@@ -1,0 +1,48 @@
+"""Add track_locks table
+
+Revision ID: e5f6a7b8c9d0
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-12 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e5f6a7b8c9d0'
+down_revision = 'c3d4e5f6a7b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'track_locks',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('spotify_playlist_id', sa.String(255), nullable=False),
+        sa.Column('track_uri', sa.String(255), nullable=False),
+        sa.Column('position', sa.Integer(), nullable=False),
+        sa.Column('lock_tier', sa.String(20), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint(
+            'user_id', 'spotify_playlist_id', 'track_uri',
+            name='uq_track_lock_user_playlist_track',
+        ),
+    )
+    op.create_index('ix_track_locks_user_id', 'track_locks', ['user_id'])
+    op.create_index(
+        'ix_track_lock_playlist',
+        'track_locks',
+        ['user_id', 'spotify_playlist_id'],
+    )
+
+
+def downgrade():
+    op.drop_index('ix_track_lock_playlist', table_name='track_locks')
+    op.drop_index('ix_track_locks_user_id', table_name='track_locks')
+    op.drop_table('track_locks')

--- a/shuffify/routes/core.py
+++ b/shuffify/routes/core.py
@@ -333,7 +333,10 @@ def callback():
         return redirect(url_for("main.index"))
 
     except AuthenticationError as e:
-        logger.error(f"Authentication failed: {e}")
+        if "not registered" in str(e):
+            logger.warning(f"Authentication failed: {e}")
+        else:
+            logger.error(f"Authentication failed: {e}")
         session.pop("spotify_token", None)
         session.pop("user_data", None)
         flash(

--- a/shuffify/services/track_lock_service.py
+++ b/shuffify/services/track_lock_service.py
@@ -368,6 +368,7 @@ class TrackLockService:
                 user_id, playlist_id
             )
         except Exception as e:
+            db.session.rollback()
             logger.warning(
                 "Failed to query track locks for "
                 "%s: %s — proceeding without locks",
@@ -386,6 +387,7 @@ class TrackLockService:
                 user_id, playlist_id
             )
         except Exception as e:
+            db.session.rollback()
             logger.warning(
                 "Failed to query track locks for "
                 "%s: %s — proceeding without locks",
@@ -405,6 +407,7 @@ class TrackLockService:
                 user_id, playlist_id, new_uris
             )
         except Exception as e:
+            db.session.rollback()
             logger.warning(
                 "Failed to reconcile locks after "
                 "reorder for %s: %s",


### PR DESCRIPTION
## Summary

Production investigation found the `track_locks` table was never created in Neon PostgreSQL — the Alembic migration was missed when the TrackLock model was added in `c51f31b`. This caused `UndefinedTable` errors on every scheduled job since Apr 9.

- **Add Alembic migration** for `track_locks` table (columns, FK, unique constraint, indexes)
- **Fix DB session poisoning** — `safe_*` fallback methods now call `db.session.rollback()` before returning defaults, preventing `InFailedSqlTransaction` cascade
- **Reduce log noise** — Spotify 403 "not registered" auth errors downgraded from ERROR to WARNING (expected for non-allowlisted users in Development Mode)

## Test plan

- [ ] Verify migration applies cleanly on deploy (auto-upgrade in `_init_database()`)
- [ ] Confirm `UndefinedTable` errors stop appearing in DO runtime logs
- [ ] Confirm `InFailedSqlTransaction` cascade errors stop
- [ ] Verify lock feature works end-to-end in Workshop UI
- [ ] Verify Spotify 403 auth attempts log at WARNING level

🤖 Generated with [Claude Code](https://claude.com/claude-code)