### PR TITLE
chore: add migration drift tests and fix executor lint

### DIFF
--- a/shuffify/services/executors/drip_executor.py
+++ b/shuffify/services/executors/drip_executor.py
@@ -279,5 +279,3 @@ def _mark_dripped_as_promoted(
             "Failed to mark dripped tracks as "
             "promoted: %s", e
         )
-
-

--- a/shuffify/services/executors/rotate_executor.py
+++ b/shuffify/services/executors/rotate_executor.py
@@ -520,5 +520,3 @@ def _rotate_swap(
         "tracks_added": swapped,
         "tracks_total": actual_total,
     }
-
-

--- a/shuffify/services/executors/shuffle_executor.py
+++ b/shuffify/services/executors/shuffle_executor.py
@@ -234,5 +234,3 @@ def _auto_snapshot_before_shuffle(
             "Auto-snapshot before scheduled "
             f"shuffle failed: {snap_err}"
         )
-
-

--- a/tests/test_migration_drift.py
+++ b/tests/test_migration_drift.py
@@ -1,0 +1,70 @@
+"""Test that Alembic migrations match SQLAlchemy model definitions.
+
+Catches the case where a model is added but ``flask db migrate``
+was never run to generate the corresponding migration file.
+
+Note: Migrations contain PostgreSQL-specific DDL (ALTER COLUMN, CHECK
+constraints) and cannot be executed against SQLite. These tests use
+static analysis of migration files instead.
+"""
+
+import os
+import re
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def model_table_names():
+    """Get all table names defined in SQLAlchemy models."""
+    from shuffify.models.db import db
+    return set(db.metadata.tables.keys())
+
+
+@pytest.fixture(scope="module")
+def migration_table_names():
+    """Parse migration files to find all tables created by migrations."""
+    migrations_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "migrations", "versions",
+    )
+    created_tables = set()
+    pattern = re.compile(r"""op\.create_table\(\s*['"](\w+)['"]""")
+
+    for filename in os.listdir(migrations_dir):
+        if not filename.endswith(".py"):
+            continue
+        filepath = os.path.join(migrations_dir, filename)
+        with open(filepath) as f:
+            content = f.read()
+        for match in pattern.finditer(content):
+            created_tables.add(match.group(1))
+
+    return created_tables
+
+
+class TestMigrationDrift:
+    """Verify that migration files cover all model definitions."""
+
+    def test_all_model_tables_have_migrations(
+        self, model_table_names, migration_table_names
+    ):
+        """Every table defined in models must have a create_table
+        in migrations."""
+        missing = model_table_names - migration_table_names
+        assert not missing, (
+            f"Tables defined in models but missing from migrations: "
+            f"{sorted(missing)}. "
+            f"Run: flask db migrate -m 'add <table>'"
+        )
+
+    def test_no_orphan_migration_tables(
+        self, model_table_names, migration_table_names
+    ):
+        """Migrations should not create tables that no model defines."""
+        orphans = migration_table_names - model_table_names
+        assert not orphans, (
+            f"Tables created by migrations but not defined in models: "
+            f"{sorted(orphans)}. "
+            f"Remove the model or delete the migration."
+        )


### PR DESCRIPTION
## Summary

Follow-up from the production investigation retro (PR #197). Adds guardrails to prevent the missing-migration class of bug from recurring.

- **Migration drift tests** — 2 static-analysis tests that parse migration files and compare against model metadata. Catches missing `create_table` migrations without needing a database connection (migrations are PostgreSQL-specific, can't run against SQLite)
- **Fix W391 lint errors** — Remove trailing blank lines from 3 executor files. `flake8 shuffify/` is now fully clean
- **Production DB audit** — Verified all 15 model tables have corresponding migrations. No gaps found beyond the track_locks table (fixed in #197)

## Test plan

- [x] `flake8 shuffify/` — 0 errors (previously 3 W391)
- [x] `pytest tests/test_migration_drift.py -v` — 2 passed in 0.82s
- [x] `pytest tests/services/test_track_lock_service.py tests/routes/test_core_routes.py tests/routes/test_track_locks_routes.py tests/test_migration_drift.py` — 53 passed, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)