### PR TITLE
Fix OAuth CSRF: add state parameter to authorization flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **OAuth CSRF State Parameter** - Added `state` parameter to OAuth authorization flow per RFC 6749 Section 10.12
+  - Login route generates a cryptographically random state token via `secrets.token_urlsafe(32)` and stores it in session
+  - State token threaded through `AuthService` and `SpotifyClient` to `SpotifyAuthManager`
+  - Callback route validates the returned state against the stored session state
+  - Mismatched or missing state rejects the callback with a user-friendly error
+  - State token consumed (removed from session) after validation to prevent replay
+
 ### Added
 - **Track-Level Locks** - Per-track position locks to protect individual tracks from automated operations
   - Two lock tiers: Standard (30-day auto-expiry, 1 click) and Super (permanent, 2 clicks)

--- a/shuffify/routes/core.py
+++ b/shuffify/routes/core.py
@@ -2,7 +2,9 @@
 Core routes: home page, static pages, health check, authentication.
 """
 
+import hmac
 import logging
+import secrets
 from datetime import datetime, timezone
 
 from flask import (
@@ -58,9 +60,7 @@ def index():
             return render_template("index.html")
 
         try:
-            client = AuthService.get_authenticated_client(
-                session["spotify_token"]
-            )
+            client = AuthService.get_authenticated_client(session["spotify_token"])
             user = AuthService.get_user_data(client)
 
             playlist_service = PlaylistService(client)
@@ -77,30 +77,24 @@ def index():
             try:
                 db_user = get_db_user()
                 if db_user:
-                    dashboard_data = (
-                        DashboardService.get_dashboard_data(
-                            user_id=db_user.id,
-                            last_login_at=getattr(
-                                db_user,
-                                "last_login_at",
-                                None,
-                            ),
-                        )
+                    dashboard_data = DashboardService.get_dashboard_data(
+                        user_id=db_user.id,
+                        last_login_at=getattr(
+                            db_user,
+                            "last_login_at",
+                            None,
+                        ),
                     )
-                    preferences = (
-                        PlaylistPreferenceService
-                        .get_user_preferences(db_user.id)
+                    preferences = PlaylistPreferenceService.get_user_preferences(
+                        db_user.id
                     )
                     if preferences:
                         (
                             favorite_playlists,
                             visible_playlists,
                             hidden_playlists,
-                        ) = (
-                            PlaylistPreferenceService
-                            .apply_preferences(
-                                playlists, preferences
-                            )
+                        ) = PlaylistPreferenceService.apply_preferences(
+                            playlists, preferences
                         )
             except Exception as e:
                 logger.warning(
@@ -110,10 +104,7 @@ def index():
                     e,
                 )
 
-            logger.debug(
-                f"User {user.get('display_name', 'Unknown')} "
-                f"loaded dashboard"
-            )
+            logger.debug(f"User {user.get('display_name', 'Unknown')} loaded dashboard")
             return render_template(
                 "dashboard.html",
                 favorite_playlists=favorite_playlists,
@@ -167,13 +158,13 @@ def health():
         overall_status = "healthy"
 
     return (
-        jsonify({
-            "status": overall_status,
-            "timestamp": datetime.now(
-                timezone.utc
-            ).isoformat(),
-            "scheduler": scheduler_metrics,
-        }),
+        jsonify(
+            {
+                "status": overall_status,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "scheduler": scheduler_metrics,
+            }
+        ),
         200,
     )
 
@@ -199,19 +190,19 @@ def login():
         # Clear any existing session data
         session.pop("spotify_token", None)
         session.pop("user_data", None)
+
+        state = secrets.token_urlsafe(32)
+        session["oauth_state"] = state
         session.modified = True
 
-        auth_url = AuthService.get_auth_url()
-        logger.debug(
-            f"Redirecting to Spotify auth: {auth_url}"
-        )
+        auth_url = AuthService.get_auth_url(state=state)
+        logger.debug(f"Redirecting to Spotify auth: {auth_url}")
         return redirect(auth_url)
 
     except AuthenticationError as e:
         logger.error(f"Login error: {e}")
         flash(
-            "An error occurred during login. "
-            "Please try again.",
+            "An error occurred during login. Please try again.",
             "error",
         )
         return redirect(url_for("main.index"))
@@ -220,17 +211,14 @@ def login():
 @main.route("/callback")
 def callback():
     """Handle OAuth callback from Spotify."""
-    logger.debug(
-        f"Callback received with args: {request.args}"
-    )
+    logger.debug(f"Callback received with args: {request.args}")
 
     # Check for OAuth errors
     error = request.args.get("error")
     if error:
         logger.error(f"OAuth error: {error}")
         flash(
-            f"OAuth Error: "
-            f"{request.args.get('error_description', 'Unknown error')}",
+            f"OAuth Error: {request.args.get('error_description', 'Unknown error')}",
             "error",
         )
         return redirect(url_for("main.index"))
@@ -240,32 +228,36 @@ def callback():
     if not code:
         logger.error("No authorization code in callback")
         flash(
-            "No authorization code received from Spotify. "
-            "Please try again.",
+            "No authorization code received from Spotify. Please try again.",
+            "error",
+        )
+        return redirect(url_for("main.index"))
+
+    # Validate CSRF state parameter
+    callback_state = request.args.get("state")
+    stored_state = session.pop("oauth_state", None)
+    if not stored_state or not hmac.compare_digest(stored_state, callback_state or ""):
+        logger.error("OAuth state mismatch: possible CSRF attack")
+        flash(
+            "Authentication failed due to a security check. Please try again.",
             "error",
         )
         return redirect(url_for("main.index"))
 
     try:
         # Exchange code for token
-        token_data = AuthService.exchange_code_for_token(
-            code
-        )
+        token_data = AuthService.exchange_code_for_token(code)
         session["spotify_token"] = token_data
 
         # Validate by fetching user data
-        _, user_data = (
-            AuthService.authenticate_and_get_user(token_data)
-        )
+        _, user_data = AuthService.authenticate_and_get_user(token_data)
         session["user_data"] = user_data
 
         # Upsert user record in database (non-blocking)
         is_new_user = False
         db_user = None
         try:
-            result = UserService.upsert_from_spotify(
-                user_data
-            )
+            result = UserService.upsert_from_spotify(user_data)
             is_new_user = result.is_new
             db_user = result.user
         except Exception as e:
@@ -285,8 +277,7 @@ def callback():
                     token_data["refresh_token"],
                 )
                 logger.debug(
-                    f"Stored encrypted refresh token "
-                    f"for user {user_data['id']}"
+                    f"Stored encrypted refresh token for user {user_data['id']}"
                 )
             except Exception as e:
                 logger.warning(
@@ -297,9 +288,7 @@ def callback():
         # Record login event (non-blocking)
         if db_user:
             try:
-                flask_session_id = getattr(
-                    session, "sid", None
-                )
+                flask_session_id = getattr(session, "sid", None)
                 LoginHistoryService.record_login(
                     user_id=db_user.id,
                     request=request,
@@ -320,9 +309,7 @@ def callback():
             log_activity(
                 user_id=db_user.id,
                 activity_type=ActivityType.LOGIN,
-                description=(
-                    "Logged in via Spotify OAuth"
-                ),
+                description=("Logged in via Spotify OAuth"),
             )
 
         logger.info(
@@ -340,8 +327,7 @@ def callback():
         session.pop("spotify_token", None)
         session.pop("user_data", None)
         flash(
-            "Error connecting to Spotify. "
-            "Please try again.",
+            "Error connecting to Spotify. Please try again.",
             "error",
         )
         return redirect(url_for("main.index"))
@@ -354,31 +340,22 @@ def logout():
     try:
         user_data = session.get("user_data")
         if user_data and user_data.get("id"):
-            db_user = UserService.get_by_spotify_id(
-                user_data["id"]
-            )
+            db_user = UserService.get_by_spotify_id(user_data["id"])
             if db_user:
-                flask_session_id = getattr(
-                    session, "sid", None
-                )
+                flask_session_id = getattr(session, "sid", None)
                 LoginHistoryService.record_logout(
                     user_id=db_user.id,
                     session_id=flask_session_id,
                 )
     except Exception as e:
-        logger.warning(
-            f"Failed to record logout: {e}. "
-            f"Logout continues."
-        )
+        logger.warning(f"Failed to record logout: {e}. Logout continues.")
 
     # Log logout activity (non-blocking)
     try:
         user_data = session.get("user_data", {})
         spotify_id = user_data.get("id")
         if spotify_id:
-            db_user = UserService.get_by_spotify_id(
-                spotify_id
-            )
+            db_user = UserService.get_by_spotify_id(spotify_id)
             if db_user:
                 log_activity(
                     user_id=db_user.id,

--- a/shuffify/services/auth_service.py
+++ b/shuffify/services/auth_service.py
@@ -28,9 +28,12 @@ class AuthService:
     """Service for managing Spotify OAuth authentication."""
 
     @staticmethod
-    def get_auth_url() -> str:
+    def get_auth_url(state: Optional[str] = None) -> str:
         """
         Generate the Spotify authorization URL.
+
+        Args:
+            state: Optional CSRF state token for OAuth security.
 
         Returns:
             The authorization URL to redirect users to.
@@ -40,7 +43,7 @@ class AuthService:
         """
         try:
             client = SpotifyClient()
-            return client.get_auth_url()
+            return client.get_auth_url(state=state)
         except Exception as e:
             logger.error(f"Failed to generate auth URL: {e}", exc_info=True)
             raise AuthenticationError(f"Failed to generate authorization URL: {e}")

--- a/shuffify/spotify/client.py
+++ b/shuffify/spotify/client.py
@@ -157,9 +157,12 @@ class SpotifyClient:
     # Authentication Methods
     # =========================================================================
 
-    def get_auth_url(self) -> str:
+    def get_auth_url(self, state: Optional[str] = None) -> str:
         """
         Get the Spotify authorization URL.
+
+        Args:
+            state: Optional CSRF state token for OAuth security.
 
         Returns:
             Authorization URL for user to visit.
@@ -167,7 +170,7 @@ class SpotifyClient:
         Raises:
             SpotifyAuthError: If URL generation fails.
         """
-        return self._auth_manager.get_auth_url()
+        return self._auth_manager.get_auth_url(state=state)
 
     def get_token(self, code: str) -> Dict[str, Any]:
         """
@@ -283,9 +286,7 @@ class SpotifyClient:
         self._ensure_authenticated()
         return self._api.update_playlist_tracks(playlist_id, track_uris)
 
-    def search_playlists(
-        self, query: str, limit: int = 10
-    ) -> List[Dict[str, Any]]:
+    def search_playlists(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
         """
         Search for playlists by name.
 

--- a/tests/routes/test_core_routes.py
+++ b/tests/routes/test_core_routes.py
@@ -8,6 +8,7 @@ Health endpoint (/health) is tested in tests/test_health_db.py.
 import time
 from unittest.mock import patch, MagicMock
 
+
 class TestIndexRoute:
     """Tests for GET /."""
 
@@ -33,9 +34,7 @@ class TestIndexRoute:
     ):
         mock_is_auth.return_value = True
         mock_client = MagicMock()
-        mock_auth_svc.get_authenticated_client.return_value = (
-            mock_client
-        )
+        mock_auth_svc.get_authenticated_client.return_value = mock_client
         mock_auth_svc.get_user_data.return_value = {
             "id": "user123",
             "display_name": "Test User",
@@ -63,8 +62,8 @@ class TestIndexRoute:
         from shuffify.services import AuthenticationError
 
         mock_is_auth.return_value = True
-        mock_auth_svc.get_authenticated_client.side_effect = (
-            AuthenticationError("expired")
+        mock_auth_svc.get_authenticated_client.side_effect = AuthenticationError(
+            "expired"
         )
 
         resp = auth_client.get("/")
@@ -98,29 +97,36 @@ class TestLoginRoute:
             assert resp.status_code == 302
 
     @patch("shuffify.routes.core.AuthService")
-    def test_with_legal_consent_redirects_to_spotify(
-        self, mock_auth_svc, db_app
-    ):
+    def test_with_legal_consent_redirects_to_spotify(self, mock_auth_svc, db_app):
         mock_auth_svc.get_auth_url.return_value = (
             "https://accounts.spotify.com/authorize?test=1"
         )
         with db_app.test_client() as client:
             resp = client.get("/login?legal_consent=true")
             assert resp.status_code == 302
-            assert (
-                "accounts.spotify.com"
-                in resp.headers["Location"]
-            )
+            assert "accounts.spotify.com" in resp.headers["Location"]
 
     @patch("shuffify.routes.core.AuthService")
-    def test_auth_error_during_login_redirects(
-        self, mock_auth_svc, db_app
-    ):
+    def test_login_stores_oauth_state_in_session(self, mock_auth_svc, db_app):
+        """Login should generate a CSRF state token matching session value."""
+        mock_auth_svc.get_auth_url.return_value = (
+            "https://accounts.spotify.com/authorize?test=1"
+        )
+        with db_app.test_client() as client:
+            resp = client.get("/login?legal_consent=true")
+            assert resp.status_code == 302
+            call_kwargs = mock_auth_svc.get_auth_url.call_args
+            state_value = call_kwargs.kwargs.get("state")
+            assert state_value is not None
+            assert len(state_value) > 0
+            with client.session_transaction() as sess:
+                assert sess.get("oauth_state") == state_value
+
+    @patch("shuffify.routes.core.AuthService")
+    def test_auth_error_during_login_redirects(self, mock_auth_svc, db_app):
         from shuffify.services import AuthenticationError
 
-        mock_auth_svc.get_auth_url.side_effect = (
-            AuthenticationError("config error")
-        )
+        mock_auth_svc.get_auth_url.side_effect = AuthenticationError("config error")
         with db_app.test_client() as client:
             resp = client.get("/login?legal_consent=true")
             assert resp.status_code == 302
@@ -133,8 +139,7 @@ class TestCallbackRoute:
         """OAuth error parameter should redirect to index."""
         with db_app.test_client() as client:
             resp = client.get(
-                "/callback?error=access_denied"
-                "&error_description=User+denied+access"
+                "/callback?error=access_denied&error_description=User+denied+access"
             )
             assert resp.status_code == 302
 
@@ -142,6 +147,34 @@ class TestCallbackRoute:
         """No authorization code should redirect to index."""
         with db_app.test_client() as client:
             resp = client.get("/callback")
+            assert resp.status_code == 302
+
+    def test_missing_state_redirects(self, db_app):
+        """Callback without state parameter should reject."""
+        with db_app.test_client() as client:
+            resp = client.get("/callback?code=test_auth_code")
+            assert resp.status_code == 302
+
+    def test_mismatched_state_redirects(self, db_app):
+        """Callback with wrong state should reject."""
+        with db_app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["oauth_state"] = "correct_state"
+            resp = client.get("/callback?code=test_auth_code&state=wrong_state")
+            assert resp.status_code == 302
+
+    def test_state_without_session_redirects(self, db_app):
+        """Callback with state but no session state should reject."""
+        with db_app.test_client() as client:
+            resp = client.get("/callback?code=test_auth_code&state=some_state")
+            assert resp.status_code == 302
+
+    def test_session_state_but_no_url_state_redirects(self, db_app):
+        """Session has state but URL omits state parameter — should reject."""
+        with db_app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["oauth_state"] = "stored_state"
+            resp = client.get("/callback?code=test_auth_code")
             assert resp.status_code == 302
 
     @patch("shuffify.routes.core.LoginHistoryService")
@@ -171,41 +204,73 @@ class TestCallbackRoute:
         )
         mock_upsert_result = MagicMock()
         mock_upsert_result.is_new = False
-        mock_user_svc.upsert_from_spotify.return_value = (
-            mock_upsert_result
-        )
+        mock_user_svc.upsert_from_spotify.return_value = mock_upsert_result
         mock_user_svc.get_by_spotify_id.return_value = None
 
         with db_app.test_client() as client:
-            resp = client.get(
-                "/callback?code=test_auth_code"
-            )
+            with client.session_transaction() as sess:
+                sess["oauth_state"] = "valid_state"
+            resp = client.get("/callback?code=test_auth_code&state=valid_state")
             assert resp.status_code == 302
             assert resp.headers["Location"].endswith("/")
 
+    @patch("shuffify.routes.core.LoginHistoryService")
+    @patch("shuffify.routes.core.UserService")
     @patch("shuffify.routes.core.AuthService")
-    def test_auth_failure_during_callback(
-        self, mock_auth_svc, db_app
+    def test_state_consumed_after_callback(
+        self,
+        mock_auth_svc,
+        mock_user_svc,
+        mock_login_hist,
+        db_app,
     ):
+        """State token should be removed from session after use."""
+        mock_auth_svc.exchange_code_for_token.return_value = {
+            "access_token": "new_token",
+            "token_type": "Bearer",
+            "expires_at": time.time() + 3600,
+            "refresh_token": "new_refresh",
+        }
+        mock_client = MagicMock()
+        mock_auth_svc.authenticate_and_get_user.return_value = (
+            mock_client,
+            {
+                "id": "user123",
+                "display_name": "Test User",
+                "images": [],
+            },
+        )
+        mock_upsert_result = MagicMock()
+        mock_upsert_result.is_new = False
+        mock_user_svc.upsert_from_spotify.return_value = mock_upsert_result
+        mock_user_svc.get_by_spotify_id.return_value = None
+
+        with db_app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["oauth_state"] = "one_time_state"
+            client.get("/callback?code=test_auth_code&state=one_time_state")
+            with client.session_transaction() as sess:
+                assert "oauth_state" not in sess
+
+    @patch("shuffify.routes.core.AuthService")
+    def test_auth_failure_during_callback(self, mock_auth_svc, db_app):
         from shuffify.services import AuthenticationError
 
-        mock_auth_svc.exchange_code_for_token.side_effect = (
-            AuthenticationError("invalid code")
+        mock_auth_svc.exchange_code_for_token.side_effect = AuthenticationError(
+            "invalid code"
         )
 
         with db_app.test_client() as client:
-            resp = client.get(
-                "/callback?code=bad_code"
-            )
+            with client.session_transaction() as sess:
+                sess["oauth_state"] = "valid_state"
+            resp = client.get("/callback?code=bad_code&state=valid_state")
             assert resp.status_code == 302
 
 
 class TestLogoutRoute:
     """Tests for GET /logout."""
 
-    def test_logout_clears_session_and_redirects(
-        self, auth_client
-    ):
+    def test_logout_clears_session_and_redirects(self, auth_client):
         """Logout should clear session and redirect to index."""
         resp = auth_client.get("/logout")
         assert resp.status_code == 302
@@ -256,9 +321,7 @@ class TestDashboardDisplayNameFallback:
         """Dashboard shows 'Welcome!' when display_name is None."""
         mock_is_auth.return_value = True
         mock_client = MagicMock()
-        mock_auth_svc.get_authenticated_client.return_value = (
-            mock_client
-        )
+        mock_auth_svc.get_authenticated_client.return_value = mock_client
         mock_auth_svc.get_user_data.return_value = {
             "id": "user_no_name",
             "display_name": None,
@@ -295,9 +358,7 @@ class TestDashboardDisplayNameFallback:
         """Returning user sees 'Welcome back!' not 'Welcome back, None!'."""
         mock_is_auth.return_value = True
         mock_client = MagicMock()
-        mock_auth_svc.get_authenticated_client.return_value = (
-            mock_client
-        )
+        mock_auth_svc.get_authenticated_client.return_value = mock_client
         mock_auth_svc.get_user_data.return_value = {
             "id": "user_no_name_returning",
             "display_name": None,

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -5,8 +5,7 @@ Tests cover OAuth flow, token validation, and client creation.
 """
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
-import time
+from unittest.mock import Mock, patch
 
 from shuffify.services import (
     AuthService,
@@ -32,12 +31,12 @@ class TestAuthServiceTokenValidation:
 
     def test_validate_session_token_missing_access_token(self):
         """Token missing access_token should return False."""
-        token = {'token_type': 'Bearer'}
+        token = {"token_type": "Bearer"}
         assert AuthService.validate_session_token(token) is False
 
     def test_validate_session_token_missing_token_type(self):
         """Token missing token_type should return False."""
-        token = {'access_token': 'some_token'}
+        token = {"access_token": "some_token"}
         assert AuthService.validate_session_token(token) is False
 
     def test_validate_token_structure_raises_on_non_dict(self):
@@ -49,27 +48,43 @@ class TestAuthServiceTokenValidation:
     def test_validate_token_structure_raises_on_missing_keys(self):
         """Token with missing keys should raise TokenValidationError."""
         with pytest.raises(TokenValidationError) as exc_info:
-            AuthService._validate_token_structure({'token_type': 'Bearer'})
+            AuthService._validate_token_structure({"token_type": "Bearer"})
         assert "missing required keys" in str(exc_info.value)
 
 
 class TestAuthServiceGetAuthUrl:
     """Tests for get_auth_url method."""
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_get_auth_url_success(self, mock_client_class, app_context):
         """Should return authorization URL from SpotifyClient."""
         mock_instance = Mock()
-        mock_instance.get_auth_url.return_value = 'https://accounts.spotify.com/authorize?test=1'
+        mock_instance.get_auth_url.return_value = (
+            "https://accounts.spotify.com/authorize?test=1"
+        )
         mock_client_class.return_value = mock_instance
 
         url = AuthService.get_auth_url()
 
-        assert url == 'https://accounts.spotify.com/authorize?test=1'
+        assert url == "https://accounts.spotify.com/authorize?test=1"
         mock_client_class.assert_called_once()
-        mock_instance.get_auth_url.assert_called_once()
+        mock_instance.get_auth_url.assert_called_once_with(state=None)
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
+    def test_get_auth_url_with_state(self, mock_client_class, app_context):
+        """Should forward state parameter to SpotifyClient."""
+        mock_instance = Mock()
+        mock_instance.get_auth_url.return_value = (
+            "https://accounts.spotify.com/authorize?test=1&state=abc123"
+        )
+        mock_client_class.return_value = mock_instance
+
+        url = AuthService.get_auth_url(state="abc123")
+
+        mock_instance.get_auth_url.assert_called_once_with(state="abc123")
+        assert "state=abc123" in url
+
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_get_auth_url_raises_on_failure(self, mock_client_class, app_context):
         """Should raise AuthenticationError on failure."""
         mock_instance = Mock()
@@ -84,22 +99,22 @@ class TestAuthServiceGetAuthUrl:
 class TestAuthServiceExchangeCode:
     """Tests for exchange_code_for_token method."""
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_exchange_code_success(self, mock_client_class, app_context, sample_token):
         """Should exchange code for valid token."""
         mock_instance = Mock()
         mock_instance.get_token.return_value = sample_token
         mock_client_class.return_value = mock_instance
 
-        result = AuthService.exchange_code_for_token('auth_code_123')
+        result = AuthService.exchange_code_for_token("auth_code_123")
 
         assert result == sample_token
-        mock_instance.get_token.assert_called_once_with('auth_code_123')
+        mock_instance.get_token.assert_called_once_with("auth_code_123")
 
     def test_exchange_code_with_empty_code(self, app_context):
         """Should raise AuthenticationError for empty code."""
         with pytest.raises(AuthenticationError) as exc_info:
-            AuthService.exchange_code_for_token('')
+            AuthService.exchange_code_for_token("")
         assert "No authorization code provided" in str(exc_info.value)
 
     def test_exchange_code_with_none_code(self, app_context):
@@ -108,17 +123,17 @@ class TestAuthServiceExchangeCode:
             AuthService.exchange_code_for_token(None)
         assert "No authorization code provided" in str(exc_info.value)
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_exchange_code_invalid_token_response(self, mock_client_class, app_context):
         """Should raise TokenValidationError for invalid token structure."""
         mock_instance = Mock()
-        mock_instance.get_token.return_value = {'invalid': 'token'}
+        mock_instance.get_token.return_value = {"invalid": "token"}
         mock_client_class.return_value = mock_instance
 
         with pytest.raises(TokenValidationError):
-            AuthService.exchange_code_for_token('auth_code_123')
+            AuthService.exchange_code_for_token("auth_code_123")
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_exchange_code_api_failure(self, mock_client_class, app_context):
         """Should raise AuthenticationError on API failure."""
         mock_instance = Mock()
@@ -126,14 +141,14 @@ class TestAuthServiceExchangeCode:
         mock_client_class.return_value = mock_instance
 
         with pytest.raises(AuthenticationError) as exc_info:
-            AuthService.exchange_code_for_token('auth_code_123')
+            AuthService.exchange_code_for_token("auth_code_123")
         assert "Failed to exchange code for token" in str(exc_info.value)
 
 
 class TestAuthServiceGetAuthenticatedClient:
     """Tests for get_authenticated_client method."""
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_get_authenticated_client_success(self, mock_client_class, sample_token):
         """Should return SpotifyClient instance."""
         mock_instance = Mock()
@@ -144,7 +159,7 @@ class TestAuthServiceGetAuthenticatedClient:
         assert client == mock_instance
         mock_client_class.assert_called_once_with(token=sample_token)
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
+    @patch("shuffify.services.auth_service.SpotifyClient")
     def test_get_authenticated_client_failure(self, mock_client_class, sample_token):
         """Should raise AuthenticationError on client creation failure."""
         mock_client_class.side_effect = Exception("Client init error")
@@ -176,8 +191,10 @@ class TestAuthServiceGetUserData:
 class TestAuthServiceAuthenticateAndGetUser:
     """Tests for authenticate_and_get_user method."""
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
-    def test_authenticate_and_get_user_success(self, mock_client_class, sample_token, sample_user):
+    @patch("shuffify.services.auth_service.SpotifyClient")
+    def test_authenticate_and_get_user_success(
+        self, mock_client_class, sample_token, sample_user
+    ):
         """Should return tuple of client and user data."""
         mock_instance = Mock()
         mock_instance.get_current_user.return_value = sample_user
@@ -189,16 +206,20 @@ class TestAuthServiceAuthenticateAndGetUser:
         assert user == sample_user
         mock_client_class.assert_called_once_with(token=sample_token)
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
-    def test_authenticate_and_get_user_client_failure(self, mock_client_class, sample_token):
+    @patch("shuffify.services.auth_service.SpotifyClient")
+    def test_authenticate_and_get_user_client_failure(
+        self, mock_client_class, sample_token
+    ):
         """Should raise AuthenticationError if client creation fails."""
         mock_client_class.side_effect = Exception("Client error")
 
         with pytest.raises(AuthenticationError):
             AuthService.authenticate_and_get_user(sample_token)
 
-    @patch('shuffify.services.auth_service.SpotifyClient')
-    def test_authenticate_and_get_user_user_fetch_failure(self, mock_client_class, sample_token):
+    @patch("shuffify.services.auth_service.SpotifyClient")
+    def test_authenticate_and_get_user_user_fetch_failure(
+        self, mock_client_class, sample_token
+    ):
         """Should raise AuthenticationError if user fetch fails."""
         mock_instance = Mock()
         mock_instance.get_current_user.side_effect = Exception("User fetch error")


### PR DESCRIPTION
## Summary
- Adds CSRF protection to the Spotify OAuth flow per [RFC 6749 Section 10.12](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12)
- Generates `secrets.token_urlsafe(32)` state token in `/login`, stores in session, threads through `AuthService` → `SpotifyClient` → `SpotifyAuthManager`
- Validates state in `/callback` using `hmac.compare_digest()` for constant-time comparison; consumes token after use to prevent replay

## Changes
| File | Change |
|------|--------|
| `shuffify/routes/core.py` | State generation in `/login`, validation in `/callback` |
| `shuffify/services/auth_service.py` | Added `state` parameter to `get_auth_url()` |
| `shuffify/spotify/client.py` | Added `state` parameter to `get_auth_url()` |
| `tests/routes/test_core_routes.py` | 6 new tests covering state generation, validation, mismatch, and consumption |
| `tests/services/test_auth_service.py` | 1 new test for state forwarding |
| `CHANGELOG.md` | Security section entry |

## Test plan
- [x] `flake8 shuffify/` — 0 errors
- [x] `pytest tests/routes/test_core_routes.py tests/services/test_auth_service.py -v` — 46/46 passed
- [x] Full suite: 1737 passed (30 pre-existing failures in `test_job_executor_rotate/service.py` unrelated to this change)

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)