### PR TITLE
Enforce SECRET_KEY in production config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Callback route validates the returned state against the stored session state
   - Mismatched or missing state rejects the callback with a user-friendly error
   - State token consumed (removed from session) after validation to prevent replay
+- **Production SECRET_KEY Enforcement** - Production config no longer falls back to a weak default `SECRET_KEY`
+  - `ProdConfig` overrides `SECRET_KEY` with `os.environ.get('SECRET_KEY')` — no hardcoded fallback
+  - `validate_required_env_vars()` now requires `SECRET_KEY` when `config_name='production'`
+  - Application fails fast on startup if `SECRET_KEY` is not set in production environment
+  - Development default remains for local dev convenience
 
 ### Added
 - **Track-Level Locks** - Per-track position locks to protect individual tracks from automated operations

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 # environment.  Without this guard, load_dotenv() injects the production
 # DATABASE_URL from .env at module-import time, before any fixture can
 # override it, causing tests to hang on Neon PostgreSQL connections.
-if 'pytest' not in sys.modules:
+if "pytest" not in sys.modules:
     load_dotenv()
 
 
@@ -24,99 +24,109 @@ def _resolve_database_url(fallback: str) -> str:
     Returns:
         Resolved database URL string.
     """
-    url = os.getenv('DATABASE_URL', fallback)
-    if url and url.startswith('postgres://'):
-        url = url.replace('postgres://', 'postgresql://', 1)
+    url = os.getenv("DATABASE_URL", fallback)
+    if url and url.startswith("postgres://"):
+        url = url.replace("postgres://", "postgresql://", 1)
     return url
 
 
-def validate_required_env_vars():
-    """Validate that all required environment variables are present."""
-    required_vars = ['SPOTIFY_CLIENT_ID', 'SPOTIFY_CLIENT_SECRET']
+def validate_required_env_vars(config_name=None):
+    """Validate that all required environment variables are present.
+
+    Args:
+        config_name: The configuration profile being used. When 'production',
+            SECRET_KEY is required (no weak default allowed).
+    """
+    required_vars = ["SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET"]
+    if config_name == "production":
+        required_vars.append("SECRET_KEY")
     missing = [var for var in required_vars if not os.getenv(var)]
     if missing:
         raise ValueError(f"Missing required environment variables: {missing}")
 
+
 class Config:
     """Base configuration."""
-    SECRET_KEY = os.getenv('SECRET_KEY', 'a_default_secret_key_for_development')
-    SESSION_COOKIE_NAME = os.getenv('SESSION_COOKIE_NAME', 'shuffify_session')
-    SPOTIFY_CLIENT_ID = os.getenv('SPOTIFY_CLIENT_ID')
-    SPOTIFY_CLIENT_SECRET = os.getenv('SPOTIFY_CLIENT_SECRET')
+
+    SECRET_KEY = os.getenv("SECRET_KEY", "a_default_secret_key_for_development")
+    SESSION_COOKIE_NAME = os.getenv("SESSION_COOKIE_NAME", "shuffify_session")
+    SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
+    SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
     # The redirect URI must match the one set in your Spotify Developer Dashboard
-    SPOTIFY_REDIRECT_URI = os.getenv('SPOTIFY_REDIRECT_URI', 'http://localhost:8000/callback')
+    SPOTIFY_REDIRECT_URI = os.getenv(
+        "SPOTIFY_REDIRECT_URI", "http://localhost:8000/callback"
+    )
 
     # Redis configuration
-    REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+    REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
     # Session configuration - Redis-based storage
-    SESSION_TYPE = 'redis'
+    SESSION_TYPE = "redis"
     SESSION_PERMANENT = False
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour
-    SESSION_KEY_PREFIX = 'shuffify:session:'
+    SESSION_KEY_PREFIX = "shuffify:session:"
 
     # Session security settings for OAuth
     SESSION_COOKIE_HTTPONLY = True
-    SESSION_COOKIE_SAMESITE = 'Lax'  # More permissive for OAuth flows
+    SESSION_COOKIE_SAMESITE = "Lax"  # More permissive for OAuth flows
     SESSION_COOKIE_SECURE = False  # Set to True in production with HTTPS
 
     # Redis caching configuration for Spotify API responses
-    CACHE_KEY_PREFIX = 'shuffify:cache:'
+    CACHE_KEY_PREFIX = "shuffify:cache:"
     CACHE_DEFAULT_TTL = 300  # 5 minutes default TTL
     CACHE_PLAYLIST_TTL = 60  # 1 minute for playlist data (changes frequently)
     CACHE_USER_TTL = 600  # 10 minutes for user profile data
     CACHE_AUDIO_FEATURES_TTL = 86400  # 24 hours for audio features (rarely change)
 
     # Database configuration
-    SQLALCHEMY_DATABASE_URI = _resolve_database_url('sqlite:///shuffify.db')
+    SQLALCHEMY_DATABASE_URI = _resolve_database_url("sqlite:///shuffify.db")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # Scheduler configuration
     SCHEDULER_ENABLED = True
-    SCHEDULER_THREAD_POOL_SIZE = int(
-        os.getenv('SCHEDULER_THREAD_POOL_SIZE', '10')
-    )
+    SCHEDULER_THREAD_POOL_SIZE = int(os.getenv("SCHEDULER_THREAD_POOL_SIZE", "10"))
 
     # Application settings
     DEBUG = False
-    PORT = int(os.getenv('PORT', 8000))
-    HOST = os.getenv('HOST', '0.0.0.0')
+    PORT = int(os.getenv("PORT", 8000))
+    HOST = os.getenv("HOST", "0.0.0.0")
 
     @classmethod
     def get_spotify_credentials(cls) -> dict:
         return {
-            'client_id': cls.SPOTIFY_CLIENT_ID,
-            'client_secret': cls.SPOTIFY_CLIENT_SECRET,
-            'redirect_uri': cls.SPOTIFY_REDIRECT_URI
+            "client_id": cls.SPOTIFY_CLIENT_ID,
+            "client_secret": cls.SPOTIFY_CLIENT_SECRET,
+            "redirect_uri": cls.SPOTIFY_REDIRECT_URI,
         }
+
 
 class ProdConfig(Config):
     """Production configuration."""
+
     # Note: FLASK_ENV was removed in Flask 3.0. Use config_name parameter instead.
-    CONFIG_NAME = 'production'
+    CONFIG_NAME = "production"
+    SECRET_KEY = os.environ.get("SECRET_KEY")  # No fallback — validated on startup
     DEBUG = False
     TESTING = False
-    SCHEDULER_ENABLED = (
-        os.getenv('SCHEDULER_ENABLED', 'true').lower() == 'true'
-    )
+    SCHEDULER_ENABLED = os.getenv("SCHEDULER_ENABLED", "true").lower() == "true"
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_HTTPONLY = True
-    SESSION_COOKIE_SAMESITE = 'Lax'
+    SESSION_COOKIE_SAMESITE = "Lax"
 
     # Production Redis settings - require REDIS_URL to be set
-    REDIS_URL = os.getenv('REDIS_URL')  # Must be explicitly set in production
+    REDIS_URL = os.getenv("REDIS_URL")  # Must be explicitly set in production
 
     # Production database - PostgreSQL via Neon or Railway
-    SQLALCHEMY_DATABASE_URI = _resolve_database_url('sqlite:///shuffify.db')
+    SQLALCHEMY_DATABASE_URI = _resolve_database_url("sqlite:///shuffify.db")
 
     # PostgreSQL engine options: connection pooling and SSL for managed providers
     SQLALCHEMY_ENGINE_OPTIONS = {
-        'pool_size': 5,
-        'pool_recycle': 300,
-        'pool_pre_ping': True,
-        'connect_args': (
-            {'sslmode': 'require'}
-            if os.getenv('DATABASE_URL', '').startswith('postgres')
+        "pool_size": 5,
+        "pool_recycle": 300,
+        "pool_pre_ping": True,
+        "connect_args": (
+            {"sslmode": "require"}
+            if os.getenv("DATABASE_URL", "").startswith("postgres")
             else {}
         ),
     }
@@ -124,27 +134,21 @@ class ProdConfig(Config):
 
 class DevConfig(Config):
     """Development configuration."""
+
     # Note: FLASK_ENV was removed in Flask 3.0. Use config_name parameter instead.
-    CONFIG_NAME = 'development'
+    CONFIG_NAME = "development"
     DEBUG = True
     TESTING = True
     SESSION_COOKIE_SECURE = False
 
     # Development Redis settings - fallback to localhost
-    REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+    REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
     # Development database - PostgreSQL if DATABASE_URL is set, else SQLite
-    SQLALCHEMY_DATABASE_URI = _resolve_database_url(
-        'sqlite:///shuffify_dev.db'
-    )
+    SQLALCHEMY_DATABASE_URI = _resolve_database_url("sqlite:///shuffify_dev.db")
 
-    SCHEDULER_ENABLED = (
-        os.getenv('SCHEDULER_ENABLED', 'true').lower() == 'true'
-    )
+    SCHEDULER_ENABLED = os.getenv("SCHEDULER_ENABLED", "true").lower() == "true"
+
 
 # Dictionary for easy config selection
-config = {
-    'development': DevConfig,
-    'production': ProdConfig,
-    'default': DevConfig
-} 
+config = {"development": DevConfig, "production": ProdConfig, "default": DevConfig}

--- a/shuffify/__init__.py
+++ b/shuffify/__init__.py
@@ -135,14 +135,11 @@ def _init_redis(app):
             return client
         except redis.ConnectionError as e:
             logger.warning(
-                "Redis connection failed: %s. "
-                "Falling back to filesystem sessions.",
+                "Redis connection failed: %s. Falling back to filesystem sessions.",
                 e,
             )
     else:
-        logger.warning(
-            "REDIS_URL not configured. Using filesystem sessions."
-        )
+        logger.warning("REDIS_URL not configured. Using filesystem sessions.")
 
     app.config["SESSION_TYPE"] = "filesystem"
     app.config["SESSION_FILE_DIR"] = "./.flask_session/"
@@ -219,11 +216,11 @@ def _init_database(app):
                 # In development without migrations dir, fall back to
                 # db.create_all() for convenience.
                 migrations_dir = os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)),
-                    'migrations'
+                    os.path.dirname(os.path.dirname(__file__)), "migrations"
                 )
                 if os.path.isdir(migrations_dir):
                     from flask_migrate import upgrade
+
                     try:
                         upgrade()
                     except Exception as mig_err:
@@ -269,9 +266,7 @@ def _apply_security_headers(app):
         # Prevent clickjacking
         response.headers["X-Frame-Options"] = "DENY"
         # Control referrer information leakage
-        response.headers["Referrer-Policy"] = (
-            "strict-origin-when-cross-origin"
-        )
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
 
         # HSTS: only in production (development uses HTTP)
         if not app.debug:
@@ -308,7 +303,7 @@ def create_app(config_name=None):
 
     # Validate required environment variables
     try:
-        validate_required_env_vars()
+        validate_required_env_vars(config_name)
         logger.info("Environment validation passed")
     except ValueError as e:
         logger.error("Environment validation failed: %s", str(e))
@@ -342,24 +337,20 @@ def create_app(config_name=None):
     # Apply rate limits to auth endpoints
     if _limiter is not None:
         try:
-            app.view_functions["main.login"] = _limiter.limit(
-                "10/minute"
-            )(app.view_functions["main.login"])
-            app.view_functions["main.callback"] = _limiter.limit(
-                "20/minute"
-            )(app.view_functions["main.callback"])
+            app.view_functions["main.login"] = _limiter.limit("10/minute")(
+                app.view_functions["main.login"]
+            )
+            app.view_functions["main.callback"] = _limiter.limit("20/minute")(
+                app.view_functions["main.callback"]
+            )
             # Resource-intensive endpoints
-            app.view_functions["main.shuffle"] = _limiter.limit(
-                "5/minute"
-            )(app.view_functions["main.shuffle"])
-            app.view_functions[
-                "main.workshop_commit"
-            ] = _limiter.limit("10/minute")(
+            app.view_functions["main.shuffle"] = _limiter.limit("5/minute")(
+                app.view_functions["main.shuffle"]
+            )
+            app.view_functions["main.workshop_commit"] = _limiter.limit("10/minute")(
                 app.view_functions["main.workshop_commit"]
             )
-            app.view_functions[
-                "main.run_schedule_now"
-            ] = _limiter.limit("5/minute")(
+            app.view_functions["main.run_schedule_now"] = _limiter.limit("5/minute")(
                 app.view_functions["main.run_schedule_now"]
             )
             logger.info(
@@ -369,9 +360,7 @@ def create_app(config_name=None):
                 "/schedules/*/run=5/min"
             )
         except Exception as e:
-            logger.warning(
-                "Failed to apply rate limits: %s", e
-            )
+            logger.warning("Failed to apply rate limits: %s", e)
 
     # Register global error handlers
     from shuffify.error_handlers import register_error_handlers

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -14,107 +14,139 @@ class TestCreateApp:
 
     def test_create_app_development_config(self):
         """Should create app with development config."""
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-            'REDIS_URL': ''
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "REDIS_URL": "",
+            },
+        ):
             from shuffify import create_app
-            app = create_app('development')
+
+            app = create_app("development")
 
             assert app is not None
-            assert app.config['DEBUG'] is True
+            assert app.config["DEBUG"] is True
 
     def test_create_app_uses_flask_env_default(self):
         """Should use FLASK_ENV when config_name not provided."""
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-            'FLASK_ENV': 'development',
-            'REDIS_URL': ''
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "FLASK_ENV": "development",
+                "REDIS_URL": "",
+            },
+        ):
             from shuffify import create_app
+
             app = create_app()
 
-            assert app.config['DEBUG'] is True
+            assert app.config["DEBUG"] is True
 
     def test_create_app_with_redis_url(self):
         """Should configure Redis session when REDIS_URL provided."""
         mock_redis = MagicMock(spec=redis.Redis)
         mock_redis.ping.return_value = True
 
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-            'REDIS_URL': 'redis://localhost:6379/0'
-        }):
-            with patch('shuffify.redis.from_url', return_value=mock_redis):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "REDIS_URL": "redis://localhost:6379/0",
+            },
+        ):
+            with patch("shuffify.redis.from_url", return_value=mock_redis):
                 from shuffify import create_app
-                app = create_app('development')
 
-                assert app.config['SESSION_TYPE'] == 'redis'
-                assert app.config.get('SESSION_REDIS') is mock_redis
+                app = create_app("development")
+
+                assert app.config["SESSION_TYPE"] == "redis"
+                assert app.config.get("SESSION_REDIS") is mock_redis
 
     def test_create_app_redis_connection_failure_fallback(self):
         """Should fall back to filesystem when Redis connection fails."""
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-            'REDIS_URL': 'redis://localhost:6379/0'
-        }):
-            with patch('shuffify.redis.from_url') as mock_from_url:
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "REDIS_URL": "redis://localhost:6379/0",
+            },
+        ):
+            with patch("shuffify.redis.from_url") as mock_from_url:
                 mock_redis = Mock()
-                mock_redis.ping.side_effect = redis.ConnectionError("Connection refused")
+                mock_redis.ping.side_effect = redis.ConnectionError(
+                    "Connection refused"
+                )
                 mock_from_url.return_value = mock_redis
 
                 from shuffify import create_app
-                app = create_app('development')
 
-                assert app.config['SESSION_TYPE'] == 'filesystem'
+                app = create_app("development")
+
+                assert app.config["SESSION_TYPE"] == "filesystem"
 
     def test_create_app_no_redis_url(self):
         """Should use filesystem sessions when REDIS_URL not set."""
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-        }, clear=True):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+            },
+            clear=True,
+        ):
             from shuffify import create_app
+
             # Force no REDIS_URL
             import os
-            os.environ.pop('REDIS_URL', None)
 
-            app = create_app('development')
+            os.environ.pop("REDIS_URL", None)
 
-            assert app.config['SESSION_TYPE'] == 'filesystem'
+            app = create_app("development")
+
+            assert app.config["SESSION_TYPE"] == "filesystem"
 
     def test_create_app_registers_blueprints(self):
         """Should register main blueprint."""
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-            'REDIS_URL': ''
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "REDIS_URL": "",
+            },
+        ):
             from shuffify import create_app
-            app = create_app('development')
+
+            app = create_app("development")
 
             # Check that routes are registered
             rules = [rule.rule for rule in app.url_map.iter_rules()]
-            assert '/' in rules
-            assert '/health' in rules
+            assert "/" in rules
+            assert "/health" in rules
 
     def test_create_app_debug_adds_no_cache_headers(self):
         """Should add no-cache headers in debug mode."""
-        with patch.dict('os.environ', {
-            'SPOTIFY_CLIENT_ID': 'test_id',
-            'SPOTIFY_CLIENT_SECRET': 'test_secret',
-            'REDIS_URL': ''
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "REDIS_URL": "",
+            },
+        ):
             from shuffify import create_app
-            app = create_app('development')
+
+            app = create_app("development")
 
             with app.test_client() as client:
-                response = client.get('/health')
-                assert 'no-cache' in response.headers.get('Cache-Control', '')
+                response = client.get("/health")
+                assert "no-cache" in response.headers.get("Cache-Control", "")
 
 
 class TestGetRedisClient:
@@ -123,6 +155,7 @@ class TestGetRedisClient:
     def test_get_redis_client_returns_none_when_not_configured(self):
         """Should return None when Redis not configured."""
         import shuffify
+
         # Reset the global
         shuffify._redis_client = None
 
@@ -132,6 +165,7 @@ class TestGetRedisClient:
     def test_get_redis_client_returns_client_when_configured(self):
         """Should return Redis client when configured."""
         import shuffify
+
         mock_redis = Mock(spec=redis.Redis)
         shuffify._redis_client = mock_redis
 
@@ -148,6 +182,7 @@ class TestGetSpotifyCache:
     def test_get_spotify_cache_returns_none_when_redis_not_configured(self):
         """Should return None when Redis not configured."""
         import shuffify
+
         shuffify._redis_client = None
 
         result = shuffify.get_spotify_cache()
@@ -180,11 +215,11 @@ class TestGetSpotifyCache:
 
         # Create a minimal Flask app for the test to avoid Redis connection
         app = Flask(__name__)
-        app.config['CACHE_KEY_PREFIX'] = 'test:cache:'
-        app.config['CACHE_DEFAULT_TTL'] = 300
-        app.config['CACHE_PLAYLIST_TTL'] = 120  # Custom TTL
-        app.config['CACHE_USER_TTL'] = 600
-        app.config['CACHE_AUDIO_FEATURES_TTL'] = 86400
+        app.config["CACHE_KEY_PREFIX"] = "test:cache:"
+        app.config["CACHE_DEFAULT_TTL"] = 300
+        app.config["CACHE_PLAYLIST_TTL"] = 120  # Custom TTL
+        app.config["CACHE_USER_TTL"] = 600
+        app.config["CACHE_AUDIO_FEATURES_TTL"] = 86400
 
         with app.app_context():
             result = shuffify.get_spotify_cache()
@@ -203,16 +238,15 @@ class TestRedisClientCreation:
         """Should create Redis client from URL."""
         from shuffify import _create_redis_client
 
-        with patch('shuffify.redis.from_url') as mock_from_url:
+        with patch("shuffify.redis.from_url") as mock_from_url:
             mock_client = Mock(spec=redis.Redis)
             mock_from_url.return_value = mock_client
 
-            result = _create_redis_client('redis://localhost:6379/0')
+            result = _create_redis_client("redis://localhost:6379/0")
 
             assert result is mock_client
             mock_from_url.assert_called_once_with(
-                'redis://localhost:6379/0',
-                decode_responses=False
+                "redis://localhost:6379/0", decode_responses=False
             )
 
 
@@ -223,27 +257,89 @@ class TestConfigIntegration:
         """Should have Redis configuration settings."""
         from config import Config
 
-        assert hasattr(Config, 'REDIS_URL')
-        assert hasattr(Config, 'SESSION_TYPE')
-        assert hasattr(Config, 'SESSION_KEY_PREFIX')
-        assert hasattr(Config, 'CACHE_KEY_PREFIX')
-        assert hasattr(Config, 'CACHE_PLAYLIST_TTL')
-        assert hasattr(Config, 'CACHE_USER_TTL')
-        assert hasattr(Config, 'CACHE_AUDIO_FEATURES_TTL')
+        assert hasattr(Config, "REDIS_URL")
+        assert hasattr(Config, "SESSION_TYPE")
+        assert hasattr(Config, "SESSION_KEY_PREFIX")
+        assert hasattr(Config, "CACHE_KEY_PREFIX")
+        assert hasattr(Config, "CACHE_PLAYLIST_TTL")
+        assert hasattr(Config, "CACHE_USER_TTL")
+        assert hasattr(Config, "CACHE_AUDIO_FEATURES_TTL")
 
     def test_production_config_requires_redis_url(self):
         """Production config should have REDIS_URL from environment."""
         from config import ProdConfig
 
         # In production, REDIS_URL should be explicitly set
-        assert hasattr(ProdConfig, 'REDIS_URL')
+        assert hasattr(ProdConfig, "REDIS_URL")
 
     def test_development_config_has_default_redis_url(self):
         """Development config should have default Redis URL."""
         from config import DevConfig
 
         # Should have a default for local development
-        assert DevConfig.REDIS_URL is not None or hasattr(DevConfig, 'REDIS_URL')
+        assert DevConfig.REDIS_URL is not None or hasattr(DevConfig, "REDIS_URL")
+
+
+class TestSecretKeyValidation:
+    """Tests for SECRET_KEY enforcement in production config."""
+
+    def test_production_requires_secret_key(self):
+        """validate_required_env_vars should reject missing SECRET_KEY in production."""
+        from config import validate_required_env_vars
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+            },
+            clear=False,
+        ):
+            # Remove SECRET_KEY if present
+            import os
+
+            os.environ.pop("SECRET_KEY", None)
+            with pytest.raises(ValueError, match="SECRET_KEY"):
+                validate_required_env_vars("production")
+
+    def test_production_passes_with_secret_key(self):
+        """validate_required_env_vars should pass when SECRET_KEY is set in production."""
+        from config import validate_required_env_vars
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "SECRET_KEY": "a-real-secret-from-env",
+            },
+        ):
+            validate_required_env_vars("production")  # Should not raise
+
+    def test_development_allows_missing_secret_key(self):
+        """validate_required_env_vars should not require SECRET_KEY in development."""
+        from config import validate_required_env_vars
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+            },
+            clear=False,
+        ):
+            import os
+
+            os.environ.pop("SECRET_KEY", None)
+            validate_required_env_vars("development")  # Should not raise
+
+    def test_prod_config_no_weak_default(self):
+        """ProdConfig should not inherit the weak dev default for SECRET_KEY."""
+        from config import ProdConfig
+
+        # ProdConfig.SECRET_KEY should be whatever os.environ.get returns,
+        # NOT the hardcoded 'a_default_secret_key_for_development'
+        assert ProdConfig.SECRET_KEY != "a_default_secret_key_for_development"
 
 
 class TestSecurityHeaders:
@@ -263,8 +359,7 @@ class TestSecurityHeaders:
         """All responses should include Referrer-Policy."""
         response = client.get("/health")
         assert (
-            response.headers.get("Referrer-Policy")
-            == "strict-origin-when-cross-origin"
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
         )
 
     def test_hsts_not_present_in_debug_mode(self, client):
@@ -279,13 +374,16 @@ class TestSecurityHeaders:
 
         os.environ.pop("DATABASE_URL", None)
 
-        with patch.dict("os.environ", {
-            "SPOTIFY_CLIENT_ID": "test_id",
-            "SPOTIFY_CLIENT_SECRET": "test_secret",
-            "SPOTIFY_REDIRECT_URI": "http://localhost:5000/callback",
-            "SECRET_KEY": "test-secret-key-for-testing",
-            "REDIS_URL": "",
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "SPOTIFY_REDIRECT_URI": "http://localhost:5000/callback",
+                "SECRET_KEY": "test-secret-key-for-testing",
+                "REDIS_URL": "",
+            },
+        ):
             from shuffify import create_app
 
             app = create_app("production")
@@ -293,9 +391,7 @@ class TestSecurityHeaders:
 
             with app.test_client() as prod_client:
                 response = prod_client.get("/health")
-                hsts = response.headers.get(
-                    "Strict-Transport-Security"
-                )
+                hsts = response.headers.get("Strict-Transport-Security")
                 assert hsts is not None
                 assert "max-age=31536000" in hsts
                 assert "includeSubDomains" in hsts
@@ -306,6 +402,5 @@ class TestSecurityHeaders:
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert (
-            response.headers.get("Referrer-Policy")
-            == "strict-origin-when-cross-origin"
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
         )


### PR DESCRIPTION
## Summary
- **ProdConfig** overrides `SECRET_KEY` with `os.environ.get("SECRET_KEY")` — no weak fallback
- **`validate_required_env_vars()`** now accepts `config_name` and requires `SECRET_KEY` when production
- App fails fast on startup if `SECRET_KEY` is missing in production; dev default preserved for local use

Fixes #211

## Test plan
- [x] `test_production_requires_secret_key` — missing SECRET_KEY raises ValueError in production
- [x] `test_production_passes_with_secret_key` — validation passes when SECRET_KEY is set
- [x] `test_development_allows_missing_secret_key` — dev mode doesn't require SECRET_KEY
- [x] `test_prod_config_no_weak_default` — ProdConfig never uses the hardcoded dev default
- [x] Full test suite: 1742 passed, 30 pre-existing failures (unrelated app context issues)
- [x] flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)