### PR TITLE
Add Content-Security-Policy header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Callback route validates the returned state against the stored session state
   - Mismatched or missing state rejects the callback with a user-friendly error
   - State token consumed (removed from session) after validation to prevent replay
+- **Content-Security-Policy Header** - Added CSP header to all responses for defense-in-depth against XSS
+  - Restricts scripts to `'self'`, Tailwind CDN, jsdelivr (SortableJS), and inline scripts
+  - Restricts images to `'self'`, Spotify image CDNs (`i.scdn.co`, `*.spotifycdn.com`), and data URIs
+  - Blocks object embeds, restricts frame ancestors, locks down base-uri and form-action to `'self'`
+  - Complements existing Jinja2 autoescaping with a browser-enforced second layer
 - **Production SECRET_KEY Enforcement** - Production config no longer falls back to a weak default `SECRET_KEY`
   - `ProdConfig` overrides `SECRET_KEY` with `os.environ.get('SECRET_KEY')` — no hardcoded fallback
   - `validate_required_env_vars()` now requires `SECRET_KEY` when `config_name='production'`

--- a/shuffify/__init__.py
+++ b/shuffify/__init__.py
@@ -268,6 +268,21 @@ def _apply_security_headers(app):
         # Control referrer information leakage
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
 
+        # Content Security Policy — defense-in-depth against XSS
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "script-src 'self' https://cdn.tailwindcss.com "
+            "https://cdn.jsdelivr.net 'unsafe-inline'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' https://i.scdn.co https://*.spotifycdn.com data:; "
+            "connect-src 'self'; "
+            "font-src 'self'; "
+            "object-src 'none'; "
+            "frame-ancestors 'none'; "
+            "base-uri 'self'; "
+            "form-action 'self'"
+        )
+
         # HSTS: only in production (development uses HTTP)
         if not app.debug:
             response.headers["Strict-Transport-Security"] = (

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -396,6 +396,43 @@ class TestSecurityHeaders:
                 assert "max-age=31536000" in hsts
                 assert "includeSubDomains" in hsts
 
+    def test_csp_header_present(self, client):
+        """All responses should include Content-Security-Policy."""
+        response = client.get("/health")
+        csp = response.headers.get("Content-Security-Policy")
+        assert csp is not None
+
+    def test_csp_default_src_self(self, client):
+        """CSP should restrict default-src to 'self'."""
+        csp = client.get("/health").headers["Content-Security-Policy"]
+        assert "default-src 'self'" in csp
+
+    def test_csp_script_src_allows_cdns(self, client):
+        """CSP should allow Tailwind and jsdelivr CDNs for scripts."""
+        csp = client.get("/health").headers["Content-Security-Policy"]
+        assert "https://cdn.tailwindcss.com" in csp
+        assert "https://cdn.jsdelivr.net" in csp
+
+    def test_csp_img_src_allows_spotify(self, client):
+        """CSP should allow Spotify image CDNs."""
+        csp = client.get("/health").headers["Content-Security-Policy"]
+        assert "https://i.scdn.co" in csp
+
+    def test_csp_blocks_object_embeds(self, client):
+        """CSP should block object/embed elements."""
+        csp = client.get("/health").headers["Content-Security-Policy"]
+        assert "object-src 'none'" in csp
+
+    def test_csp_frame_ancestors_none(self, client):
+        """CSP should prevent framing (reinforces X-Frame-Options)."""
+        csp = client.get("/health").headers["Content-Security-Policy"]
+        assert "frame-ancestors 'none'" in csp
+
+    def test_csp_on_non_health_routes(self, client):
+        """CSP should be present on all routes."""
+        response = client.get("/")
+        assert response.headers.get("Content-Security-Policy") is not None
+
     def test_security_headers_on_non_health_routes(self, client):
         """Security headers should be on all routes, not just /health."""
         response = client.get("/")


### PR DESCRIPTION
## Summary
- Adds a `Content-Security-Policy` header to all responses via `_apply_security_headers()`
- Allows Tailwind CDN, jsdelivr (SortableJS), and Spotify image CDNs (`i.scdn.co`, `*.spotifycdn.com`)
- Blocks object embeds, restricts frame ancestors, base-uri, and form-action to `'self'`
- Complements existing Jinja2 autoescaping with a browser-enforced second layer of XSS protection

Fixes #212

## Test plan
- [x] 7 new tests in `TestSecurityHeaders` verifying CSP directives
- [x] All 13 security header tests pass
- [x] Full test suite: 1749 passed, 30 pre-existing failures (unrelated app_context issues)
- [x] flake8 clean
- [x] `/simplify` review: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)