### PR TITLE
Add missing db.session.rollback() in raid dedupe handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Restricts images to `'self'`, Spotify image CDNs (`i.scdn.co`, `*.spotifycdn.com`), and data URIs
   - Blocks object embeds, restricts frame ancestors, locks down base-uri and form-action to `'self'`
   - Complements existing Jinja2 autoescaping with a browser-enforced second layer
+- **DB Session Rollback in Raid Dedupe** - Added missing `db.session.rollback()` in 3 exception handlers in `raid_dedupe.py`
+  - Prevents cascading `InFailedSqlTransaction` errors when a DB query fails during deduplication
+  - Applies to `RaidPlaylistLink`, `PlaylistPair`, and `PendingRaidTrack` query exception handlers
 - **Production SECRET_KEY Enforcement** - Production config no longer falls back to a weak default `SECRET_KEY`
   - `ProdConfig` overrides `SECRET_KEY` with `os.environ.get('SECRET_KEY')` — no hardcoded fallback
   - `validate_required_env_vars()` now requires `SECRET_KEY` when `config_name='production'`

--- a/shuffify/services/raid_dedupe.py
+++ b/shuffify/services/raid_dedupe.py
@@ -8,6 +8,7 @@ target + raid playlist + archive + dismissed tracks.
 import logging
 
 from shuffify.models.db import (
+    db,
     PlaylistPair,
     RaidPlaylistLink,
     PendingRaidTrack,
@@ -38,16 +39,9 @@ def build_full_exclusion_set(api, target_id, user_id):
     try:
         target_tracks = api.get_playlist_tracks(target_id)
         target_track_count = len(target_tracks)
-        exclusion |= {
-            t.get("uri")
-            for t in target_tracks
-            if t.get("uri")
-        }
+        exclusion |= {t.get("uri") for t in target_tracks if t.get("uri")}
     except Exception as e:
-        logger.warning(
-            "Could not fetch target tracks for "
-            "dedupe: %s", e
-        )
+        logger.warning("Could not fetch target tracks for dedupe: %s", e)
 
     try:
         link = RaidPlaylistLink.query.filter_by(
@@ -55,19 +49,11 @@ def build_full_exclusion_set(api, target_id, user_id):
             target_playlist_id=target_id,
         ).first()
         if link:
-            raid_tracks = api.get_playlist_tracks(
-                link.raid_playlist_id
-            )
-            exclusion |= {
-                t.get("uri")
-                for t in raid_tracks
-                if t.get("uri")
-            }
+            raid_tracks = api.get_playlist_tracks(link.raid_playlist_id)
+            exclusion |= {t.get("uri") for t in raid_tracks if t.get("uri")}
     except Exception as e:
-        logger.warning(
-            "Could not fetch raid playlist tracks "
-            "for dedupe: %s", e
-        )
+        db.session.rollback()
+        logger.warning("Could not fetch raid playlist tracks for dedupe: %s", e)
 
     try:
         pair = PlaylistPair.query.filter_by(
@@ -75,19 +61,11 @@ def build_full_exclusion_set(api, target_id, user_id):
             production_playlist_id=target_id,
         ).first()
         if pair:
-            archive_tracks = api.get_playlist_tracks(
-                pair.archive_playlist_id
-            )
-            exclusion |= {
-                t.get("uri")
-                for t in archive_tracks
-                if t.get("uri")
-            }
+            archive_tracks = api.get_playlist_tracks(pair.archive_playlist_id)
+            exclusion |= {t.get("uri") for t in archive_tracks if t.get("uri")}
     except Exception as e:
-        logger.warning(
-            "Could not fetch archive tracks for "
-            "dedupe: %s", e
-        )
+        db.session.rollback()
+        logger.warning("Could not fetch archive tracks for dedupe: %s", e)
 
     try:
         dismissed = PendingRaidTrack.query.filter_by(
@@ -97,9 +75,7 @@ def build_full_exclusion_set(api, target_id, user_id):
         ).all()
         exclusion |= {t.track_uri for t in dismissed}
     except Exception as e:
-        logger.warning(
-            "Could not fetch dismissed tracks for "
-            "dedupe: %s", e
-        )
+        db.session.rollback()
+        logger.warning("Could not fetch dismissed tracks for dedupe: %s", e)
 
     return exclusion, target_track_count

--- a/tests/services/test_raid_dedupe.py
+++ b/tests/services/test_raid_dedupe.py
@@ -3,10 +3,12 @@ Tests for chain-wide raid deduplication.
 """
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from shuffify.models.db import (
-    db, PlaylistPair, RaidPlaylistLink,
+    db,
+    PlaylistPair,
+    RaidPlaylistLink,
     PendingRaidTrack,
 )
 from shuffify.services.user_service import UserService
@@ -20,11 +22,13 @@ from shuffify.enums import PendingRaidStatus
 def user(db_app):
     """Provide a test user."""
     with db_app.app_context():
-        result = UserService.upsert_from_spotify({
-            "id": "dedupeuser1",
-            "display_name": "Dedupe User",
-            "images": [],
-        })
+        result = UserService.upsert_from_spotify(
+            {
+                "id": "dedupeuser1",
+                "display_name": "Dedupe User",
+                "images": [],
+            }
+        )
         yield result.user
 
 
@@ -38,24 +42,18 @@ def mock_api():
 class TestBuildFullExclusionSet:
     """Tests for build_full_exclusion_set."""
 
-    def test_includes_target_tracks(
-        self, user, mock_api
-    ):
+    def test_includes_target_tracks(self, user, mock_api):
         mock_api.get_playlist_tracks.return_value = [
             {"uri": "spotify:track:t1"},
             {"uri": "spotify:track:t2"},
         ]
 
-        result, count = build_full_exclusion_set(
-            mock_api, "target1", user.id
-        )
+        result, count = build_full_exclusion_set(mock_api, "target1", user.id)
         assert "spotify:track:t1" in result
         assert "spotify:track:t2" in result
         assert count == 2
 
-    def test_includes_raid_playlist_tracks(
-        self, user, mock_api
-    ):
+    def test_includes_raid_playlist_tracks(self, user, mock_api):
         link = RaidPlaylistLink(
             user_id=user.id,
             target_playlist_id="target2",
@@ -71,19 +69,13 @@ class TestBuildFullExclusionSet:
                 return [{"uri": "spotify:track:r1"}]
             return []
 
-        mock_api.get_playlist_tracks.side_effect = (
-            get_tracks
-        )
+        mock_api.get_playlist_tracks.side_effect = get_tracks
 
-        result, _ = build_full_exclusion_set(
-            mock_api, "target2", user.id
-        )
+        result, _ = build_full_exclusion_set(mock_api, "target2", user.id)
         assert "spotify:track:t1" in result
         assert "spotify:track:r1" in result
 
-    def test_includes_archive_tracks(
-        self, user, mock_api
-    ):
+    def test_includes_archive_tracks(self, user, mock_api):
         pair = PlaylistPair(
             user_id=user.id,
             production_playlist_id="target3",
@@ -99,18 +91,12 @@ class TestBuildFullExclusionSet:
                 return [{"uri": "spotify:track:a1"}]
             return []
 
-        mock_api.get_playlist_tracks.side_effect = (
-            get_tracks
-        )
+        mock_api.get_playlist_tracks.side_effect = get_tracks
 
-        result, _ = build_full_exclusion_set(
-            mock_api, "target3", user.id
-        )
+        result, _ = build_full_exclusion_set(mock_api, "target3", user.id)
         assert "spotify:track:a1" in result
 
-    def test_includes_dismissed_tracks(
-        self, user, mock_api
-    ):
+    def test_includes_dismissed_tracks(self, user, mock_api):
         pending = PendingRaidTrack(
             user_id=user.id,
             target_playlist_id="target4",
@@ -123,9 +109,7 @@ class TestBuildFullExclusionSet:
 
         mock_api.get_playlist_tracks.return_value = []
 
-        result, _ = build_full_exclusion_set(
-            mock_api, "target4", user.id
-        )
+        result, _ = build_full_exclusion_set(mock_api, "target4", user.id)
         assert "spotify:track:dismissed1" in result
 
     def test_full_chain_dedupe(self, user, mock_api):
@@ -166,30 +150,86 @@ class TestBuildFullExclusionSet:
                 return [{"uri": "spotify:track:a1"}]
             return []
 
-        mock_api.get_playlist_tracks.side_effect = (
-            get_tracks
-        )
+        mock_api.get_playlist_tracks.side_effect = get_tracks
 
-        result, _ = build_full_exclusion_set(
-            mock_api, "target5", user.id
-        )
+        result, _ = build_full_exclusion_set(mock_api, "target5", user.id)
         assert "spotify:track:t1" in result
         assert "spotify:track:r1" in result
         assert "spotify:track:a1" in result
         assert "spotify:track:d1" in result
         assert len(result) == 4
 
-    def test_handles_api_errors_gracefully(
-        self, user, mock_api
-    ):
+    def test_handles_api_errors_gracefully(self, user, mock_api):
         """API errors should not crash, just return
         partial results."""
-        mock_api.get_playlist_tracks.side_effect = (
-            Exception("API error")
-        )
+        mock_api.get_playlist_tracks.side_effect = Exception("API error")
 
-        result, _ = build_full_exclusion_set(
-            mock_api, "target_err", user.id
-        )
+        result, _ = build_full_exclusion_set(mock_api, "target_err", user.id)
         # Should return empty set, not raise
         assert isinstance(result, set)
+
+
+class TestRollbackOnDbFailure:
+    """Verify db.session.rollback() is called when DB queries fail."""
+
+    def test_raid_link_query_failure_rolls_back(self, user, mock_api):
+        mock_api.get_playlist_tracks.return_value = [{"uri": "spotify:track:t1"}]
+
+        with (
+            patch("shuffify.services.raid_dedupe.RaidPlaylistLink") as MockLink,
+            patch("shuffify.services.raid_dedupe.db") as mock_db,
+        ):
+            MockLink.query.filter_by.side_effect = Exception("DB error")
+
+            result, _ = build_full_exclusion_set(mock_api, "target_pl", user.id)
+
+        mock_db.session.rollback.assert_called()
+        assert "spotify:track:t1" in result
+
+    def test_playlist_pair_query_failure_rolls_back(self, user, mock_api):
+        mock_api.get_playlist_tracks.return_value = [{"uri": "spotify:track:t1"}]
+
+        with (
+            patch("shuffify.services.raid_dedupe.PlaylistPair") as MockPair,
+            patch("shuffify.services.raid_dedupe.db") as mock_db,
+        ):
+            MockPair.query.filter_by.side_effect = Exception("DB error")
+
+            result, _ = build_full_exclusion_set(mock_api, "target_pl", user.id)
+
+        mock_db.session.rollback.assert_called()
+        assert "spotify:track:t1" in result
+
+    def test_pending_raid_query_failure_rolls_back(self, user, mock_api):
+        mock_api.get_playlist_tracks.return_value = [{"uri": "spotify:track:t1"}]
+
+        with (
+            patch("shuffify.services.raid_dedupe.PendingRaidTrack") as MockPending,
+            patch("shuffify.services.raid_dedupe.db") as mock_db,
+        ):
+            MockPending.query.filter_by.side_effect = Exception("DB error")
+
+            result, _ = build_full_exclusion_set(mock_api, "target_pl", user.id)
+
+        mock_db.session.rollback.assert_called()
+        assert "spotify:track:t1" in result
+
+    def test_all_db_queries_fail_rolls_back_each(self, user, mock_api):
+        """All three DB failures should each trigger a rollback."""
+        mock_api.get_playlist_tracks.return_value = [{"uri": "spotify:track:t1"}]
+
+        with (
+            patch("shuffify.services.raid_dedupe.RaidPlaylistLink") as MockLink,
+            patch("shuffify.services.raid_dedupe.PlaylistPair") as MockPair,
+            patch("shuffify.services.raid_dedupe.PendingRaidTrack") as MockPending,
+            patch("shuffify.services.raid_dedupe.db") as mock_db,
+        ):
+            MockLink.query.filter_by.side_effect = Exception("fail")
+            MockPair.query.filter_by.side_effect = Exception("fail")
+            MockPending.query.filter_by.side_effect = Exception("fail")
+
+            result, count = build_full_exclusion_set(mock_api, "target_pl", user.id)
+
+        assert mock_db.session.rollback.call_count == 3
+        assert result == {"spotify:track:t1"}
+        assert count == 1


### PR DESCRIPTION
## Summary
- Added `db.session.rollback()` to 3 exception handlers in `raid_dedupe.py` that catch DB query failures without cleaning up the session
- Prevents cascading `InFailedSqlTransaction` errors when `RaidPlaylistLink`, `PlaylistPair`, or `PendingRaidTrack` queries fail during deduplication
- Added 4 new tests verifying rollback is called on each DB failure path

Fixes #201

## Test plan
- [x] All 10 `test_raid_dedupe.py` tests pass (6 existing + 4 new)
- [x] `flake8 shuffify/` clean
- [x] Full test suite: 1751 passed, 32 pre-existing failures (all `test_job_executor_rotate/service.py` app context issues, unrelated)
- [x] `/simplify` review — no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)