### PR TITLE
Fix db_app fixture flakiness in batch test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **db_app Fixture Flakiness in Batch Test Runs** - Fixed intermittent `no such table` errors during test teardown
+  - Root cause: fixtures called `create_app("development")` then overrode `SQLALCHEMY_DATABASE_URI` to `:memory:`, but the engine was already cached with the file-based URI from `_init_database`
+  - Added `TestConfig` class to `config.py` with `sqlite:///:memory:` URI so the engine is correctly initialized with StaticPool from the start
+  - Updated `db_app` and `app` fixtures to use `create_app("testing")`
+  - Added resilient teardown: `try/except` around `db.drop_all()` and `db.engine.dispose()` for proper cleanup
+
 ### Security
 - **OAuth CSRF State Parameter** - Added `state` parameter to OAuth authorization flow per RFC 6749 Section 10.12
   - Login route generates a cryptographically random state token via `secrets.token_urlsafe(32)` and stores it in session

--- a/config.py
+++ b/config.py
@@ -150,5 +150,23 @@ class DevConfig(Config):
     SCHEDULER_ENABLED = os.getenv("SCHEDULER_ENABLED", "true").lower() == "true"
 
 
+class TestConfig(Config):
+    """Test configuration for isolated, in-memory test runs.
+
+    Uses SQLite in-memory so Flask-SQLAlchemy auto-configures StaticPool,
+    ensuring all connections share the same database within a test.
+    """
+
+    CONFIG_NAME = "testing"
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SCHEDULER_ENABLED = False
+
+
 # Dictionary for easy config selection
-config = {"development": DevConfig, "production": ProdConfig, "default": DevConfig}
+config = {
+    "development": DevConfig,
+    "production": ProdConfig,
+    "testing": TestConfig,
+    "default": DevConfig,
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ including mock Spotify clients, sample data, and Flask app contexts.
 """
 
 import pytest
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 import time
 
 
@@ -14,16 +14,17 @@ import time
 # Sample Data Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def sample_token():
     """A valid Spotify OAuth token."""
     return {
-        'access_token': 'test_access_token_12345',
-        'token_type': 'Bearer',
-        'expires_in': 3600,
-        'expires_at': time.time() + 3600,
-        'refresh_token': 'test_refresh_token_67890',
-        'scope': 'playlist-read-private playlist-modify-public'
+        "access_token": "test_access_token_12345",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expires_at": time.time() + 3600,
+        "refresh_token": "test_refresh_token_67890",
+        "scope": "playlist-read-private playlist-modify-public",
     }
 
 
@@ -31,11 +32,11 @@ def sample_token():
 def expired_token():
     """An expired Spotify OAuth token."""
     return {
-        'access_token': 'expired_access_token',
-        'token_type': 'Bearer',
-        'expires_in': 3600,
-        'expires_at': time.time() - 100,  # Expired
-        'refresh_token': 'test_refresh_token',
+        "access_token": "expired_access_token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expires_at": time.time() - 100,  # Expired
+        "refresh_token": "test_refresh_token",
     }
 
 
@@ -43,7 +44,7 @@ def expired_token():
 def invalid_token():
     """A token missing required fields."""
     return {
-        'token_type': 'Bearer',
+        "token_type": "Bearer",
         # Missing 'access_token'
     }
 
@@ -52,13 +53,13 @@ def invalid_token():
 def sample_user():
     """Sample Spotify user data."""
     return {
-        'id': 'user123',
-        'display_name': 'Test User',
-        'email': 'test@example.com',
-        'images': [{'url': 'https://example.com/avatar.jpg'}],
-        'country': 'US',
-        'product': 'premium',
-        'uri': 'spotify:user:user123',
+        "id": "user123",
+        "display_name": "Test User",
+        "email": "test@example.com",
+        "images": [{"url": "https://example.com/avatar.jpg"}],
+        "country": "US",
+        "product": "premium",
+        "uri": "spotify:user:user123",
     }
 
 
@@ -66,12 +67,12 @@ def sample_user():
 def sample_playlist_data():
     """Sample Spotify playlist data."""
     return {
-        'id': 'playlist123',
-        'name': 'My Test Playlist',
-        'description': 'A playlist for testing',
-        'owner': {'id': 'user123'},
-        'tracks': {'total': 10},
-        'images': [{'url': 'https://example.com/cover.jpg'}]
+        "id": "playlist123",
+        "name": "My Test Playlist",
+        "description": "A playlist for testing",
+        "owner": {"id": "user123"},
+        "tracks": {"total": 10},
+        "images": [{"url": "https://example.com/cover.jpg"}],
     }
 
 
@@ -80,26 +81,26 @@ def sample_playlists():
     """List of sample playlists."""
     return [
         {
-            'id': 'playlist1',
-            'name': 'Playlist One',
-            'owner': {'id': 'user123'},
-            'tracks': {'total': 25},
-            'collaborative': False
+            "id": "playlist1",
+            "name": "Playlist One",
+            "owner": {"id": "user123"},
+            "tracks": {"total": 25},
+            "collaborative": False,
         },
         {
-            'id': 'playlist2',
-            'name': 'Playlist Two',
-            'owner': {'id': 'user123'},
-            'tracks': {'total': 50},
-            'collaborative': False
+            "id": "playlist2",
+            "name": "Playlist Two",
+            "owner": {"id": "user123"},
+            "tracks": {"total": 50},
+            "collaborative": False,
         },
         {
-            'id': 'playlist3',
-            'name': 'Collab Playlist',
-            'owner': {'id': 'other_user'},
-            'tracks': {'total': 15},
-            'collaborative': True
-        }
+            "id": "playlist3",
+            "name": "Collab Playlist",
+            "owner": {"id": "other_user"},
+            "tracks": {"total": 15},
+            "collaborative": True,
+        },
     ]
 
 
@@ -108,17 +109,24 @@ def sample_tracks():
     """Sample track data for a playlist."""
     return [
         {
-            'id': f'track{i}',
-            'name': f'Track {i}',
-            'uri': f'spotify:track:track{i}',
-            'duration_ms': 180000 + (i * 1000),
-            'is_local': False,
-            'artists': [{'name': f'Artist {i}', 'external_urls': {'spotify': f'https://open.spotify.com/artist/artist{i}'}}],
-            'album': {
-                'name': f'Album {i}',
-                'images': [{'url': f'https://example.com/album{i}.jpg'}]
+            "id": f"track{i}",
+            "name": f"Track {i}",
+            "uri": f"spotify:track:track{i}",
+            "duration_ms": 180000 + (i * 1000),
+            "is_local": False,
+            "artists": [
+                {
+                    "name": f"Artist {i}",
+                    "external_urls": {
+                        "spotify": f"https://open.spotify.com/artist/artist{i}"
+                    },
+                }
+            ],
+            "album": {
+                "name": f"Album {i}",
+                "images": [{"url": f"https://example.com/album{i}.jpg"}],
             },
-            'external_urls': {'spotify': f'https://open.spotify.com/track/track{i}'}
+            "external_urls": {"spotify": f"https://open.spotify.com/track/track{i}"},
         }
         for i in range(1, 11)
     ]
@@ -127,20 +135,20 @@ def sample_tracks():
 @pytest.fixture
 def sample_track_uris(sample_tracks):
     """List of track URIs from sample tracks."""
-    return [track['uri'] for track in sample_tracks]
+    return [track["uri"] for track in sample_tracks]
 
 
 @pytest.fixture
 def sample_audio_features():
     """Sample audio features for tracks."""
     return {
-        f'track{i}': {
-            'tempo': 120.0 + i,
-            'energy': 0.5 + (i * 0.05),
-            'valence': 0.6 + (i * 0.03),
-            'danceability': 0.7 + (i * 0.02),
-            'acousticness': 0.3,
-            'instrumentalness': 0.1
+        f"track{i}": {
+            "tempo": 120.0 + i,
+            "energy": 0.5 + (i * 0.05),
+            "valence": 0.6 + (i * 0.03),
+            "danceability": 0.7 + (i * 0.02),
+            "acousticness": 0.3,
+            "instrumentalness": 0.1,
         }
         for i in range(1, 11)
     }
@@ -150,8 +158,15 @@ def sample_audio_features():
 # Mock Fixtures
 # =============================================================================
 
+
 @pytest.fixture
-def mock_spotify_client(sample_user, sample_playlists, sample_playlist_data, sample_tracks, sample_audio_features):
+def mock_spotify_client(
+    sample_user,
+    sample_playlists,
+    sample_playlist_data,
+    sample_tracks,
+    sample_audio_features,
+):
     """A mock SpotifyClient with pre-configured responses."""
     mock = Mock()
 
@@ -162,12 +177,12 @@ def mock_spotify_client(sample_user, sample_playlists, sample_playlist_data, sam
     mock.get_playlist_tracks.return_value = sample_tracks
     mock.get_track_audio_features.return_value = sample_audio_features
     mock.update_playlist_tracks.return_value = True
-    mock.get_auth_url.return_value = 'https://accounts.spotify.com/authorize?...'
+    mock.get_auth_url.return_value = "https://accounts.spotify.com/authorize?..."
     mock.get_token.return_value = {
-        'access_token': 'new_token',
-        'token_type': 'Bearer',
-        'expires_at': time.time() + 3600,
-        'refresh_token': 'new_refresh'
+        "access_token": "new_token",
+        "token_type": "Bearer",
+        "expires_at": time.time() + 3600,
+        "refresh_token": "new_refresh",
     }
 
     return mock
@@ -176,6 +191,7 @@ def mock_spotify_client(sample_user, sample_playlists, sample_playlist_data, sam
 @pytest.fixture
 def mock_session():
     """A mock Flask session (dict-like with modified flag)."""
+
     class MockSession(dict):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -187,21 +203,21 @@ def mock_session():
 @pytest.fixture
 def session_with_token(mock_session, sample_token):
     """A mock session pre-populated with a valid token."""
-    mock_session['spotify_token'] = sample_token
+    mock_session["spotify_token"] = sample_token
     return mock_session
 
 
 @pytest.fixture
 def session_with_state(mock_session, sample_token, sample_track_uris):
     """A mock session with token and playlist state history."""
-    mock_session['spotify_token'] = sample_token
-    mock_session['playlist_states'] = {
-        'playlist123': {
-            'states': [
+    mock_session["spotify_token"] = sample_token
+    mock_session["playlist_states"] = {
+        "playlist123": {
+            "states": [
                 sample_track_uris,  # Original state
                 sample_track_uris[::-1],  # Reversed (after shuffle)
             ],
-            'current_index': 1
+            "current_index": 1,
         }
     }
     return mock_session
@@ -211,24 +227,25 @@ def session_with_state(mock_session, sample_token, sample_track_uris):
 # Flask App Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def app():
     """Create a Flask application for testing."""
     import os
-    os.environ['SPOTIFY_CLIENT_ID'] = 'test_client_id'
-    os.environ['SPOTIFY_CLIENT_SECRET'] = 'test_client_secret'
-    os.environ['SPOTIFY_REDIRECT_URI'] = 'http://localhost:5000/callback'
-    os.environ['SECRET_KEY'] = 'test-secret-key-for-testing'
-    os.environ.pop('DATABASE_URL', None)
+
+    os.environ["SPOTIFY_CLIENT_ID"] = "test_client_id"
+    os.environ["SPOTIFY_CLIENT_SECRET"] = "test_client_secret"
+    os.environ["SPOTIFY_REDIRECT_URI"] = "http://localhost:5000/callback"
+    os.environ["SECRET_KEY"] = "test-secret-key-for-testing"
+    os.environ.pop("DATABASE_URL", None)
 
     from shuffify import create_app
-    app = create_app('development')
-    app.config['TESTING'] = True
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['SCHEDULER_ENABLED'] = False
+
+    app = create_app("testing")
 
     with app.app_context():
         from shuffify.models.db import db
+
         db.create_all()
 
     return app
@@ -277,6 +294,10 @@ def db_app():
     This fixture creates a fresh database for each test, ensuring
     complete isolation. Use this instead of the lighter `app` fixture
     when tests need to write to the database.
+
+    Uses TestConfig so the engine is created with the in-memory URI
+    from the start, ensuring Flask-SQLAlchemy auto-configures
+    StaticPool (all connections share the same in-memory database).
     """
     import os
 
@@ -287,17 +308,18 @@ def db_app():
     from shuffify import create_app
     from shuffify.models.db import db
 
-    app = create_app("development")
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    app.config["TESTING"] = True
-    app.config["SCHEDULER_ENABLED"] = False
+    app = create_app("testing")
 
     with app.app_context():
         db.drop_all()
         db.create_all()
         yield app
         db.session.remove()
-        db.drop_all()
+        try:
+            db.drop_all()
+        except Exception:
+            pass
+        db.engine.dispose()
 
 
 @pytest.fixture
@@ -317,11 +339,13 @@ def auth_client(db_app):
     from shuffify.services.user_service import UserService
 
     with db_app.app_context():
-        UserService.upsert_from_spotify({
-            "id": "user123",
-            "display_name": "Test User",
-            "images": [],
-        })
+        UserService.upsert_from_spotify(
+            {
+                "id": "user123",
+                "display_name": "Test User",
+                "images": [],
+            }
+        )
 
     with db_app.test_client() as client:
         with client.session_transaction() as sess:
@@ -348,6 +372,7 @@ def auth_client(db_app):
 def basic_algorithm():
     """An instance of BasicShuffle algorithm."""
     from shuffify.shuffle_algorithms.basic import BasicShuffle
+
     return BasicShuffle()
 
 
@@ -355,4 +380,5 @@ def basic_algorithm():
 def all_algorithms():
     """Dictionary of all available algorithms."""
     from shuffify.shuffle_algorithms.registry import ShuffleRegistry
+
     return ShuffleRegistry.get_available_algorithms()

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -362,10 +362,28 @@ class TestSecurityHeaders:
             response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
         )
 
-    def test_hsts_not_present_in_debug_mode(self, client):
+    def test_hsts_not_present_in_debug_mode(self):
         """HSTS should NOT be sent in debug/development mode."""
-        response = client.get("/health")
-        assert "Strict-Transport-Security" not in response.headers
+        import os
+        from unittest.mock import patch
+
+        os.environ.pop("DATABASE_URL", None)
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+            },
+        ):
+            from shuffify import create_app
+
+            app = create_app("development")
+            app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+            with app.test_client() as debug_client:
+                response = debug_client.get("/health")
+                assert "Strict-Transport-Security" not in response.headers
 
     def test_hsts_present_in_production_mode(self):
         """HSTS should be sent when debug is False (production)."""


### PR DESCRIPTION
## Summary
- **Root cause**: `db_app` and `app` fixtures called `create_app("development")` then overrode `SQLALCHEMY_DATABASE_URI` to `sqlite:///:memory:`. However, the engine was already cached with DevConfig's file-based URI (`sqlite:///shuffify_dev.db`) from `_init_database`, so all "in-memory" tests were actually sharing a file-based SQLite — causing intermittent `no such table` errors during teardown.
- **Fix**: Added `TestConfig` class with the correct `sqlite:///:memory:` URI, updated fixtures to use `create_app("testing")`, and added resilient teardown (`try/except` + `db.engine.dispose()`).
- Fixed `test_hsts_not_present_in_debug_mode` which relied on DevConfig's `DEBUG=True` — now creates its own debug-mode app explicitly.

Fixes #202

## Test plan
- [x] All 10 `test_raid_dedupe.py` tests pass
- [x] 934 DB-heavy tests pass (models/services/routes)
- [x] `test_hsts_not_present_in_debug_mode` passes with explicit debug app
- [x] flake8 clean
- [x] Full suite: 1750 passed, 32 failed (pre-existing app context issues in job executor tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)