### PR TITLE
feat(forensics): WOOKLYN silent-loss investigation + read-only SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Forensic SQL: WOOKLYN loss timeline** - Read-only Postgres script for reconstructing silent track-loss history on any playlist
+  - `scripts/forensics/wooklyn_loss_timeline.sql` — seven-section report (matched playlists, schedules, executions, snapshots, activity log, drift detection, restore quick-card)
+  - Joins `schedules × job_executions × playlist_snapshots × activity_log` and surfaces `drift_pre_to_next < 0` rows (silent losses missed by today's permissive verifier)
+  - Resolves playlists via UNION of `schedules.target_playlist_name` and `playlist_snapshots.playlist_name`, so renamed playlists still surface
+  - Read-only enforced via `SET default_transaction_read_only = on` + 60s `statement_timeout`
+  - Parameterized: `playlist_name_pattern` (required) and `days_back` (default 60, override via `-v days_back=N`)
+  - `scripts/forensics/run_wooklyn_timeline.sh` wrapper and `scripts/forensics/README.md` for setup + interpretation
+  - First deliverable in the WOOKLYN silent-loss investigation (`documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/`)
+
 ### Fixed
 - **db_app Fixture Flakiness in Batch Test Runs** - Fixed intermittent `no such table` errors during test teardown
   - Root cause: fixtures called `create_app("development")` then overrode `SQLALCHEMY_DATABASE_URI` to `:memory:`, but the engine was already cached with the file-based URI from `_init_database`

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/00_INVESTIGATION.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/00_INVESTIGATION.md
@@ -1,0 +1,132 @@
+# WOOKLYN Silent Track-Loss — Investigation
+
+**Session:** `wooklyn-silent-loss`
+**Date:** 2026-05-16
+**Reporter:** chrisrogers37
+**Platform:** DigitalOcean App Platform (Flask, single instance)
+
+---
+
+## Problem
+
+User's **WOOKLYN** Spotify playlist is silently losing songs during scheduled
+rotations on Shuffify. The rotate executor logs warnings about size drift but
+the parent job is still marked `success`. Shuffle / drip / raid executors have
+no post-write verification at all. The user's read: *"rotates should check
+against the target song counter. This [verify+fallback] can wrap shuffles."*
+
+## Smoking gun
+
+DigitalOcean runtime-log buffer captured on **2026-05-13 09:00:09 UTC**:
+
+```
+WARNI [shuffify.services.executors.rotate_executor]
+Schedule 11: swap size mismatch — expected 241 tracks, got 240
+```
+
+`Schedule 11` is the playlist's rotation. The drift was exactly one track and
+the job completed successfully — direct evidence of the silent-loss class.
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| DO app ID | `1ac416ce-832e-4f93-bcef-f0624c5f81c5` (`shuffify`) |
+| Instance count | 1 (no APScheduler concurrency) |
+| Last deploy | 2026-05-11 (commit `0e21cef`) |
+| Sentry DSN | NOT configured (sentry-sdk installed) |
+| Log forwarder | None |
+| DO log buffer | Small; historical losses age out |
+
+## Recent code changes that plausibly amplify the issue
+
+- `c51f31b` — Per-track position locks. Locks are excluded from the rotate
+  eligible pool (`rotate_executor.py:386-393`), which can make `swap_out_uris`
+  shorter than `swap_in_uris` even when `archive_uris` is full.
+- `e91c750` — Rotation LIFO → FIFO. Changed swap-in order but kept the same
+  count-only verifier.
+- No edits to `spotify/api.py` or `spotify/http_client.py` in the last 60 days.
+
+## Root-cause analysis
+
+| # | Category | Finding | Confidence |
+|---|----------|---------|------------|
+| RC1 | Rotate verifier permissive | `_verify_playlist_size` (`rotate_executor.py:214-253`) only raises when drift exceeds 50% of expected (`threshold = max(1, expected // 2)`). Smaller drifts log a warning and the job is marked `success`. | **High** |
+| RC2 | Rotate expected-count baseline is wrong | Expected count passed in Phase 2 swap is `len(prod_uris)` — the **original** size — at `rotate_executor.py:507-510`. When `swap_in_uris` and `swap_out_uris` diverge (locks/protect/depleted pool), the real post-swap size is `len(prod_uris) + (len(swap_in) - len(swap_out))`. The verifier is comparing against the wrong target. | **High** |
+| RC3 | Shuffle has no post-write verification | `SpotifyAPI.update_playlist_tracks` (`spotify/api.py:344-385`) PUTs batch 1 then POSTs batches 2+. It returns `True` regardless of whether later batches landed. Shuffle executor reports `tracks_total = len(shuffled_uris)` (`shuffle_executor.py:178`) without re-fetching. A network blip on a 200+ track shuffle silently truncates to ~100. | **High** |
+| RC4 | Drip is fire-and-forget | `drip_executor.py:127-130` calls `playlist_add_items` then `playlist_remove_items` with no return-value check. `_mark_dripped_as_promoted` runs after, so tracks can be marked PROMOTED in the DB without ever having landed in the target. | **High** |
+| RC5 | Raid swallows failures | `_add_to_raid_playlist` (`raid_executor.py:198-210`) wraps `playlist_add_items` in `try/except Exception` and logs `warning`. `tracks_added` reported to JobExecution is the staged DB count, not the Spotify reality. | **Medium** |
+| RC6 | Snapshots taken but never used for rollback | `_auto_snapshot_before_{rotate,shuffle,raid,drip}` snapshot the pre-state. `PlaylistSnapshotService.restore_snapshot` (`playlist_snapshot_service.py:149-178`) returns URIs — caller must re-apply via Spotify API. No executor has a rollback call site. The "we can revert" capability is dormant. | **High** |
+| RC7 | Activity log records executor's claim, not reality | `_record_success` (`base_executor.py:117-166`) logs `tracks_added`/`tracks_total` from the executor's return dict, not from a re-fetch. Audit trail can't distinguish "succeeded" from "succeeded with silent drift". | **High** |
+| RC8 | No production observability | `SENTRY_DSN` not configured. DO buffer is small. We have no way to know how many rotations have already silently dropped tracks. | **High** |
+
+## Decisions taken with the user
+
+| Decision | Value |
+|----------|-------|
+| Fix scope | F1+F2+F3+F4+F5+F6 (full slate) |
+| Verifier mode | URI **multiset** compare (catches missing **and** substituted tracks) |
+| Rollback policy | Full snapshot rollback on any verifier mismatch |
+
+## Fix plan index
+
+Each fix is an independently shippable PR. Suggested implementation order is
+listed; the user's `/claudna:implement-plan` workflow can drive them in this
+sequence:
+
+| # | File | Title | Recommended order |
+|---|------|-------|-------------------|
+| F6 | [`06_neon_forensic_sql.md`](06_neon_forensic_sql.md) | Read-only WOOKLYN loss timeline + restore candidates | **1st** (no code; tells us scope before we change anything) |
+| F1 | [`01_verify_wrapper.md`](01_verify_wrapper.md) | `BaseExecutor.verify_playlist_state` URI-set verifier | 2nd |
+| F3 | [`03_rotate_expected_math.md`](03_rotate_expected_math.md) | Correct rotate expected-URI computation | 3rd (lands with F1) |
+| F2 | [`02_snapshot_rollback.md`](02_snapshot_rollback.md) | Auto-rollback on `PlaylistVerificationError` | 4th |
+| F4 | [`04_spotify_write_api.md`](04_spotify_write_api.md) | Tighten Spotify multi-batch write contract | 5th |
+| F5 | [`05_sentry_wiring.md`](05_sentry_wiring.md) | Sentry init + executor-level WARNING capture | 6th |
+
+## Defense-in-depth picture (after all fixes land)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  JobExecutorService.execute  (base_executor.py:40)               │
+│    └─ pre-snapshot (already exists)                              │
+│    └─ executor write                                              │
+│         └─ F4: Spotify API raises on per-batch shortfall          │
+│    └─ F1: verify_playlist_state(expected_uris)                   │
+│         └─ raises PlaylistVerificationError on multiset diff      │
+│    └─ F2: catch PVE → restore_snapshot → re-apply via API         │
+│         status='failed_rolled_back', ActivityLog has diff detail  │
+│    └─ F5: Sentry captures WARNING/ERROR; tagged with schedule_id  │
+└──────────────────────────────────────────────────────────────────┘
+F6 (forensic SQL) runs out-of-band against Neon to assess past damage.
+```
+
+Three layers of protection: the write API itself raises on partial
+batches (F4), the executor verifies post-write state via URI multiset
+(F1+F3), and on failure the pre-snapshot is automatically restored (F2).
+
+## Verification (after fixes land)
+
+Per project CLAUDE.md pre-push checklist:
+
+```
+flake8 shuffify/ && pytest tests/ -v
+```
+
+Per-fix targeted tests live alongside each fix doc. End-to-end:
+
+1. Run F6's SQL in Neon read-only — capture WOOKLYN's actual loss timeline and
+   identify the most recent intact snapshot the user can restore from today.
+2. Stage F1+F3 on a preview deploy, run a controlled rotation on a throwaway
+   playlist where one URI is yanked mid-flight (simulate via mocked API). Expect
+   `PlaylistVerificationError` and `JobExecution.status = 'failed'`.
+3. Stage F2, repeat (2). Expect `status = 'failed_rolled_back'` and the
+   playlist URI list matches the pre-snapshot exactly.
+4. Stage F5, repeat (1). Expect the captured warning to appear as a Sentry
+   event tagged with `schedule_id`, `playlist_id`, `job_type`.
+
+## Out of scope
+
+- "Corrective top-up" rollback (user chose hard snapshot rollback).
+- Concurrency hardening — single DO instance; rotations don't overlap.
+- The `added_at` reorder-API migration tracked in `project_shuffle_reorder_investigation.md`.
+  F4 makes that migration safer but doesn't depend on it.

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/01_verify_wrapper.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/01_verify_wrapper.md
@@ -1,0 +1,258 @@
+# F1 — `verify_playlist_state` URI-set verifier
+
+**Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Targets:** RC1, RC2 (partial — F3 finishes RC2), RC3, RC4, RC5
+**Risk:** Low. Effort: Medium.
+
+## Context
+
+Every executor that writes to a playlist has either a 50%-tolerance count
+check (rotate) or no check at all (shuffle, raid, drip). Direct evidence:
+
+```
+WARNI [shuffify.services.executors.rotate_executor]
+Schedule 11: swap size mismatch — expected 241 tracks, got 240
+```
+
+This fix introduces a single shared helper, `verify_playlist_state`, on
+`JobExecutorService`. It re-fetches the playlist after writes and compares
+the actual track URIs to the expected URIs as a **multiset** (a playlist
+can legitimately contain duplicates). On any diff it raises a new
+`PlaylistVerificationError` carrying `expected`, `actual`, `missing`, and
+`extra` for downstream rollback (F2) and Sentry capture (F5).
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `shuffify/services/executors/base_executor.py` | New `PlaylistVerificationError` exception; new `JobExecutorService.verify_playlist_state(api, playlist_id, expected_uris, schedule_id, phase)` static method |
+| `shuffify/services/executors/rotate_executor.py` | Replace `_verify_playlist_size` call sites (lines 445-448 and 507-510) with `verify_playlist_state`; remove `_verify_playlist_size` |
+| `shuffify/services/executors/shuffle_executor.py` | After `api.update_playlist_tracks(...)` (line 157-159), call `verify_playlist_state(api, target_id, shuffled_uris, schedule.id, "shuffle")` |
+| `shuffify/services/executors/drip_executor.py` | After the add+remove pair (line 127-130), call `verify_playlist_state` for **both** target (expect `drip_uris + previous_target_uris`) and raid (expect previous raid URIs minus `drip_uris`) |
+| `shuffify/services/executors/raid_executor.py` | After `_add_to_raid_playlist` (line 106-108), if a raid link exists, call `verify_playlist_state` against the raid playlist (expect previous raid URIs ∪ `new_uris`). Remove the `try/except Exception → warning` at line 198-210 in favor of letting `verify_playlist_state` surface the failure |
+| `tests/services/executors/test_verify_playlist_state.py` | New test module (see below) |
+
+## Exception design
+
+`PlaylistVerificationError` lives in `base_executor.py` (same file as
+`JobExecutionError`) and **subclasses `JobExecutionError`** so existing
+`except JobExecutionError` blocks already in `execute_rotate`, etc., catch
+it without changes. F2 will add a narrower handler in
+`JobExecutorService.execute`.
+
+```python
+class PlaylistVerificationError(JobExecutionError):
+    """Raised when post-write playlist state diverges from expected."""
+
+    def __init__(
+        self,
+        playlist_id: str,
+        expected: list[str],
+        actual: list[str],
+        schedule_id: int,
+        phase: str,
+    ):
+        self.playlist_id = playlist_id
+        self.expected = expected
+        self.actual = actual
+        self.schedule_id = schedule_id
+        self.phase = phase
+
+        from collections import Counter
+        exp = Counter(expected)
+        act = Counter(actual)
+        # multiset diff (preserves duplicate-count semantics)
+        self.missing = list((exp - act).elements())
+        self.extra = list((act - exp).elements())
+
+        super().__init__(
+            f"Schedule {schedule_id}: {phase} verification failed — "
+            f"expected {len(expected)} tracks, got {len(actual)}, "
+            f"missing {len(self.missing)}, extra {len(self.extra)}"
+        )
+```
+
+## Helper
+
+```python
+@staticmethod
+def verify_playlist_state(
+    api: SpotifyAPI,
+    playlist_id: str,
+    expected_uris: list[str],
+    schedule_id: int,
+    phase: str,
+) -> list[str]:
+    """Re-fetch playlist and verify URI multiset matches expected.
+
+    Returns the actual URI list on success. Raises
+    PlaylistVerificationError on any multiset divergence.
+    """
+    verified = api.get_playlist_tracks(playlist_id)
+    actual_uris = [
+        t["uri"] for t in (verified or []) if t.get("uri")
+    ]
+
+    from collections import Counter
+    if Counter(actual_uris) != Counter(expected_uris):
+        raise PlaylistVerificationError(
+            playlist_id=playlist_id,
+            expected=expected_uris,
+            actual=actual_uris,
+            schedule_id=schedule_id,
+            phase=phase,
+        )
+    return actual_uris
+```
+
+Cache note: `SpotifyAPI.get_playlist_tracks` reads through `SpotifyCache` with
+a 60s TTL. The pre-write fetch and the post-write verify could collide on a
+stale cache hit. **The verify must bypass the cache.** Either:
+
+1. Call `cache.invalidate_playlist(playlist_id)` before `get_playlist_tracks`, OR
+2. Add a `bypass_cache=True` kwarg to `get_playlist_tracks` and thread it through.
+
+Recommended: option 1 — it's a one-liner and doesn't change the API surface.
+The write paths already invalidate the cache (e.g., `update_playlist_tracks`
+at `spotify/api.py:380-383`), but `playlist_add_items` / `playlist_remove_items`
+must also be checked to ensure invalidation runs before the verify reads.
+
+## Call-site changes (concrete)
+
+### Rotate (`rotate_executor.py`)
+
+Replace lines 445-448:
+```python
+expected = len(prod_uris) - len(overflow_uris)
+actual_total = _verify_playlist_size(
+    api, target_id, expected,
+    schedule.id, "overflow removal",
+)
+```
+With:
+```python
+expected_uris = [u for u in prod_uris if u not in set(overflow_uris)]
+verified = JobExecutorService.verify_playlist_state(
+    api, target_id, expected_uris, schedule.id, "overflow",
+)
+actual_total = len(verified)
+```
+
+Replace lines 507-510 — see F3, which computes `expected_uris` correctly
+for the asymmetric-swap case. F1's helper is the same; only the inputs
+change.
+
+Remove `_verify_playlist_size` (lines 214-253).
+
+### Shuffle (`shuffle_executor.py`)
+
+After line 157-159 (`api.update_playlist_tracks(target_id, shuffled_uris)`),
+add before line 162:
+
+```python
+JobExecutorService.verify_playlist_state(
+    api, target_id, shuffled_uris, schedule.id, "shuffle",
+)
+```
+
+This catches the multi-batch-truncation case (RC3) at the executor layer
+even before F4 tightens the API layer.
+
+### Drip (`drip_executor.py`)
+
+After line 130 (`api.playlist_remove_items(raid_id, drip_uris)`), before
+the DB write at 131:
+
+```python
+prev_target_uris = [
+    t.get("uri") for t in target_tracks if t.get("uri")
+]
+expected_target = drip_uris + prev_target_uris  # add at position=0
+JobExecutorService.verify_playlist_state(
+    api, target_id, expected_target, schedule.id, "drip target",
+)
+
+# Verify raid playlist: removed drip_uris from prev raid contents.
+expected_raid = [u for u in raid_uris if u not in set(drip_uris)]
+JobExecutorService.verify_playlist_state(
+    api, raid_id, expected_raid, schedule.id, "drip raid",
+)
+```
+
+If verification raises, `_mark_dripped_as_promoted` is skipped — which is
+correct, because the DB state should not advance when Spotify state is bad.
+
+### Raid (`raid_executor.py`)
+
+Replace lines 198-210 (`_add_to_raid_playlist`) so it returns the previous
+raid URIs to the caller, OR move the verification into the caller around
+lines 106-108:
+
+```python
+link = RaidLinkService.get_link_for_playlist(
+    schedule.user_id, target_id
+)
+if link:
+    prev_raid_uris = [
+        t.get("uri")
+        for t in api.get_playlist_tracks(link.raid_playlist_id) or []
+        if t.get("uri")
+    ]
+else:
+    prev_raid_uris = None
+
+_add_to_raid_playlist(
+    api, schedule.user_id, target_id, new_uris,
+)
+
+if link:
+    expected_raid = prev_raid_uris + new_uris
+    JobExecutorService.verify_playlist_state(
+        api, link.raid_playlist_id, expected_raid,
+        schedule.id, "raid pull",
+    )
+```
+
+Drop the `try/except Exception → warning` inside `_add_to_raid_playlist` so
+real errors propagate. The verify call above replaces the silent warning.
+
+## Tests (`tests/services/executors/test_verify_playlist_state.py`)
+
+```python
+def test_verify_match_returns_actual()
+def test_verify_count_drift_raises()
+def test_verify_uri_substitution_raises()       # same count, wrong tracks
+def test_verify_duplicates_match()               # legit duplicate URIs OK
+def test_verify_duplicates_diverge()             # 2 copies expected, 1 actual
+def test_verify_paginated_fetch()                # >100 tracks, mock paginates
+def test_verify_empty_playlist()
+def test_verify_invalidates_cache_before_fetch() # asserts cache.invalidate_* called
+```
+
+Mock `api.get_playlist_tracks` with `unittest.mock.Mock`. Use
+`PlaylistVerificationError` in `pytest.raises(...)` and assert on
+`exc.missing`, `exc.extra`, `exc.phase`, `exc.schedule_id`.
+
+Also update existing executor tests that assert on
+`_verify_playlist_size` to use `verify_playlist_state` instead.
+
+## Verification
+
+```bash
+flake8 shuffify/
+pytest tests/services/executors/test_verify_playlist_state.py -v
+pytest tests/ -v
+```
+
+Behavioral: deploy to a preview environment, run a controlled rotation on
+a throwaway playlist where one URI is deleted between the executor's pre-fetch
+and the verify call (mocked). Expect the JobExecution to land with
+`status='failed'` and `error_message` containing `expected …, got …, missing 1`.
+
+## Rollout note
+
+F1 alone is **stricter than today's behavior** — rotations that currently
+land in the warn-only zone will start failing once F1 ships. Without F2 (auto
+rollback) the playlist will be left in the broken state after F1 raises, so
+F1 should ship in the same release as F2 (or one preview deploy before F2)
+to avoid degrading user experience while we wait on the rollback path.

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/02_snapshot_rollback.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/02_snapshot_rollback.md
@@ -1,0 +1,197 @@
+# F2 — Auto-rollback from snapshot on verification failure
+
+**Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Targets:** RC6 (snapshots taken but unused), RC7 (audit-trail divergence)
+**Depends on:** F1 (`PlaylistVerificationError` and `verify_playlist_state` exist)
+**Risk:** Medium. Effort: Medium.
+
+## Context
+
+Pre-snapshots are already taken by `_auto_snapshot_before_{shuffle,rotate,raid,drip}`
+in each executor — the user has full backups of every pre-state. But
+`PlaylistSnapshotService.restore_snapshot` (`playlist_snapshot_service.py:149-178`)
+only returns the saved URI list; no executor calls it. When F1 starts raising
+`PlaylistVerificationError`, the playlist is left in whatever broken state Spotify
+ended up in.
+
+This fix wires the existing snapshots into a real rollback path: when F1 detects
+a divergence, the pre-snapshot is re-applied via `api.update_playlist_tracks`,
+`JobExecution.status` is set to `failed_rolled_back`, and the ActivityLog entry
+captures `expected`, `actual`, `missing_uris`, and the snapshot ID used.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `shuffify/services/executors/base_executor.py` | (a) Make `_auto_snapshot_before_*` return the created snapshot's id; (b) thread the snapshot id through to `JobExecutorService.execute`; (c) catch `PlaylistVerificationError` and run rollback; (d) record `failed_rolled_back` status |
+| `shuffify/services/executors/rotate_executor.py` | `_auto_snapshot_before_rotate` returns `snapshot_id`; pass to a small context object the executor returns alongside the result |
+| `shuffify/services/executors/shuffle_executor.py` | Same return-id contract |
+| `shuffify/services/executors/drip_executor.py` | Same return-id contract; **two** snapshots are taken (target + raid). Both ids must be threaded |
+| `shuffify/services/executors/raid_executor.py` | Same return-id contract |
+| `shuffify/services/playlist_snapshot_service.py` | (Optional) add `restore_to_playlist(snapshot_id, user_id, api)` convenience that wraps `restore_snapshot` + `api.update_playlist_tracks` |
+| `shuffify/models/db.py` | `JobExecution.status` is already a string column (`models/db.py:590-651`), so no migration. Add `JobExecution.error_metadata_json` if not already present (check column list) for structured diff payload — otherwise reuse `error_message` capped at 1000 chars |
+| `shuffify/enums.py` | Add `JobExecutionStatus` constants (`SUCCESS`, `FAILED`, `FAILED_ROLLED_BACK`, `RUNNING`) — keep as plain strings for backwards compat with existing rows |
+| `tests/services/executors/test_snapshot_rollback.py` | New test module |
+
+## Approach
+
+### A. Pass snapshot context out of executors
+
+Today, executors return `{"tracks_added": N, "tracks_total": M}`. We expand
+this to optionally include the snapshot ids taken during the run, then strip
+that context back out before persisting it to `JobExecution`:
+
+```python
+# In every executor that auto-snapshots:
+result = {
+    "tracks_added": ...,
+    "tracks_total": ...,
+    "_rollback_snapshots": [
+        {"playlist_id": target_id, "snapshot_id": tgt_snap_id},
+        # drip also adds the raid snapshot
+    ],
+}
+```
+
+`_rollback_snapshots` is consumed by `JobExecutorService.execute` and **not**
+persisted on `JobExecution` (the snapshot IDs are already discoverable from the
+`playlist_snapshots` table by `(user_id, playlist_id, created_at)`).
+
+### B. New `restore_to_playlist` convenience (recommended)
+
+```python
+# shuffify/services/playlist_snapshot_service.py
+
+@staticmethod
+def restore_to_playlist(
+    snapshot_id: int,
+    user_id: int,
+    api,                # SpotifyAPI
+) -> list[str]:
+    """Restore a snapshot to its source playlist via Spotify API.
+
+    Returns the URI list that was applied. Raises
+    PlaylistSnapshotNotFoundError if the snapshot is not found or not owned.
+    Raises whatever the Spotify API raises on write failure (caller decides
+    how to react).
+    """
+    snapshot = PlaylistSnapshotService.get_snapshot(snapshot_id, user_id)
+    uris = snapshot.track_uris or []
+    api.update_playlist_tracks(snapshot.playlist_id, uris)
+    logger.info(
+        "Restored snapshot %s to playlist %s (%d tracks)",
+        snapshot_id, snapshot.playlist_id, len(uris),
+    )
+    return uris
+```
+
+### C. Catch + rollback in `JobExecutorService.execute`
+
+Modify `execute` (`base_executor.py:40-91`):
+
+```python
+try:
+    ...
+    result = JobExecutorService._execute_job_type(schedule, api)
+    JobExecutorService._record_success(execution, schedule, result)
+
+except PlaylistVerificationError as ve:
+    JobExecutorService._record_rollback(
+        execution, schedule, api, ve, schedule_id,
+    )
+except Exception as e:
+    JobExecutorService._record_failure(
+        execution, schedule, e, schedule_id,
+    )
+```
+
+`_record_rollback` does:
+
+1. For each `_rollback_snapshots` entry attached to the in-flight result OR
+   discovered from the most recent snapshot for `(user_id, ve.playlist_id)`:
+   call `PlaylistSnapshotService.restore_to_playlist(...)`.
+2. Set `execution.status = "failed_rolled_back"`.
+3. Build a structured diff payload:
+   ```python
+   payload = {
+       "phase": ve.phase,
+       "expected_count": len(ve.expected),
+       "actual_count": len(ve.actual),
+       "missing": ve.missing[:50],   # cap for storage
+       "extra": ve.extra[:50],
+       "missing_total": len(ve.missing),
+       "extra_total": len(ve.extra),
+       "restored_snapshot_id": <id used>,
+       "restored_track_count": <len of restored>,
+   }
+   ```
+4. Persist `payload` either on a new `JobExecution.error_metadata_json` column
+   (preferred — see migration note) or, if we don't want a migration, JSON-dump
+   into the existing `error_message` field truncated at 1000 chars.
+5. Emit ActivityLog with `activity_type='SCHEDULE_RUN_ROLLED_BACK'` (new enum
+   value in `enums.py:ActivityType`) carrying the same payload.
+6. Log a high-severity message for Sentry (F5) capture.
+
+If `_record_rollback` itself fails (e.g., Spotify down), it should fall back to
+`_record_failure` and leave the playlist in its broken state — better than
+silently doing nothing.
+
+### D. Recovering snapshot context when executor didn't return it
+
+If an old-pattern executor doesn't return `_rollback_snapshots` (e.g., a future
+executor someone adds without reading this doc), `_record_rollback` should
+look up the latest snapshot by `(user_id, ve.playlist_id, created_at)` from
+`PlaylistSnapshot` and use that. This makes the rollback path robust against
+forgetful contributors.
+
+### E. New ActivityType
+
+In `shuffify/enums.py:ActivityType`, add:
+
+```python
+SCHEDULE_RUN_ROLLED_BACK = "schedule_run_rolled_back"
+```
+
+The existing `SCHEDULE_RUN` continues to mean "ran and succeeded". This
+separates the audit-trail signal cleanly.
+
+## Tests (`tests/services/executors/test_snapshot_rollback.py`)
+
+```python
+def test_rollback_restores_pre_snapshot_uris()
+def test_rollback_sets_status_failed_rolled_back()
+def test_rollback_writes_structured_payload_to_activity_log()
+def test_rollback_handles_missing_snapshot_id_falls_back_to_latest()
+def test_rollback_drip_restores_both_target_and_raid()
+def test_rollback_when_restore_fails_falls_back_to_plain_failure()
+def test_no_rollback_on_non_verification_exceptions()
+```
+
+Each test mocks `SpotifyAPI` and `PlaylistSnapshotService` and asserts on the
+DB state of `JobExecution` and `ActivityLog`.
+
+## Verification
+
+```bash
+flake8 shuffify/
+pytest tests/services/executors/test_snapshot_rollback.py -v
+pytest tests/ -v
+```
+
+End-to-end on a preview deploy:
+
+1. Create a snapshot-eligible playlist with 5 tracks. Set up a swap schedule.
+2. Patch `SpotifyAPI.playlist_add_items` to skip the actual add (simulating
+   silent Spotify dropout).
+3. Run the schedule once. Expect:
+   - `JobExecution.status == 'failed_rolled_back'`
+   - Playlist has the original 5 tracks (restored)
+   - ActivityLog entry has `phase='swap'`, `missing_total=...`
+4. Confirm the auto-snapshot still exists (retention not breached) so the
+   user can manually trigger another restore from the UI if needed.
+
+## Rollout note
+
+This fix is **only useful with F1**. Ship F1+F2 together in the same release.
+If F2 is ever delayed behind F1, document clearly that rotations may
+fail-loud-and-leave-broken-state during the gap.

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/03_rotate_expected_math.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/03_rotate_expected_math.md
@@ -1,0 +1,170 @@
+# F3 — Correct the rotate expected-URI computation
+
+**Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Targets:** RC2 (wrong baseline in rotate Phase 2)
+**Depends on:** F1 (uses `verify_playlist_state` for the verify step)
+**Risk:** Low. Effort: Small.
+
+## Context
+
+The current rotate verifier baseline is the **original** production size, used
+verbatim at `rotate_executor.py:507-510`:
+
+```python
+actual_total = _verify_playlist_size(
+    api, target_id, len(prod_uris),
+    schedule.id, "swap",
+)
+```
+
+`Phase 2` swap math is:
+
+- `swap_in_uris = archive_uris[:rotation_count]`
+- `swap_out_uris = _sample_at_most(eligible_uris, len(swap_in_uris))`
+- After writes: production has `(prod_uris ∖ swap_out_uris) ∪ swap_in_uris`
+
+When `eligible_uris` is shrunk (high `protect_count`, many locked tracks, small
+playlist), `swap_out_uris` ends up shorter than `swap_in_uris` — so the actual
+final size is `len(prod_uris) + (len(swap_in_uris) − len(swap_out_uris))`, not
+`len(prod_uris)`. The verifier was comparing against the wrong target. Even
+F1's strict check would compare against the wrong expected list without this
+fix.
+
+`Phase 1` (overflow) already passes the correct expected count
+(`len(prod_uris) - len(overflow_uris)` at line 444) but does not provide a URI
+list — F1 needs one.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `shuffify/services/executors/rotate_executor.py` | Replace verifier call sites with multiset-correct expected URI lists |
+| `tests/services/executors/test_rotate_executor.py` | Add tests for asymmetric-swap, depleted-pool, and overflow paths |
+
+## Changes (concrete)
+
+### Phase 1 (overflow), replace lines 443-457
+
+Current:
+```python
+expected = len(prod_uris) - len(overflow_uris)
+actual_total = _verify_playlist_size(
+    api, target_id, expected,
+    schedule.id, "overflow removal",
+)
+```
+
+New:
+```python
+overflow_set = set(overflow_uris)
+expected_uris = [u for u in prod_uris if u not in overflow_set]
+verified = JobExecutorService.verify_playlist_state(
+    api, target_id, expected_uris, schedule.id, "overflow",
+)
+actual_total = len(verified)
+```
+
+### Phase 2 (swap), replace lines 502-510
+
+Current:
+```python
+swapped = min(
+    len(swap_in_uris),
+    len(swap_out_uris),
+)
+
+actual_total = _verify_playlist_size(
+    api, target_id, len(prod_uris),
+    schedule.id, "swap",
+)
+```
+
+New:
+```python
+swap_out_set = set(swap_out_uris)
+expected_uris = [u for u in prod_uris if u not in swap_out_set]
+expected_uris.extend(swap_in_uris)
+
+verified = JobExecutorService.verify_playlist_state(
+    api, target_id, expected_uris, schedule.id, "swap",
+)
+actual_total = len(verified)
+
+# Report swap pair count (not symmetric — depleted pool can shorten swap_out)
+swapped = min(len(swap_in_uris), len(swap_out_uris))
+```
+
+### Order semantics
+
+Spotify's `playlist_add_items` adds at the end by default. Production today
+ends up as `(prod_uris ∖ swap_out_uris) ++ swap_in_uris` (append order). The
+expected URI list above matches that exactly. F1 compares as a **multiset**,
+so even if Spotify reorders by a position quirk, F1 won't false-fail — it
+only requires same membership and same multiplicities.
+
+### Archive verification
+
+The rotate swap also writes to the archive playlist (lines 487-488 in Phase 2,
+lines 440-442 in Phase 1). The expected archive state is
+`archive_uris ∪ new_to_archive` (Phase 1 + Phase 2) or
+`(archive_uris ∖ swap_in_uris) ∪ new_to_archive` (Phase 2 after swap-in
+removal at line 491-495). Add a second `verify_playlist_state` call for the
+archive playlist in both phases for symmetry:
+
+```python
+# After archive writes complete:
+expected_archive = [
+    *(u for u in archive_uris if u not in set(swap_in_uris)),
+    *new_to_archive,
+]
+JobExecutorService.verify_playlist_state(
+    api, archive_id, expected_archive, schedule.id, "swap archive",
+)
+```
+
+Whether to include this in F3 or save it for a follow-up: include it.
+Rotation correctness means both halves of the swap are valid. The verify
+cost is one extra paginated fetch per archive — cheap, ~1s for most users.
+
+## Tests (`tests/services/executors/test_rotate_executor.py`)
+
+Add cases:
+
+```python
+def test_swap_with_full_eligible_pool_passes()
+def test_swap_with_depleted_pool_due_to_locks()       # asymmetric counts
+def test_swap_with_high_protect_count()               # asymmetric counts
+def test_overflow_uses_correct_expected_uri_list()
+def test_archive_state_verified_after_swap()
+def test_archive_state_verified_after_overflow()
+```
+
+Each uses `unittest.mock.Mock` for `SpotifyAPI`, asserts on the multiset of
+URIs passed to `verify_playlist_state` (since F1 raises on diff, the test
+controls the mock's `get_playlist_tracks` return to be exactly the expected
+URIs).
+
+Update any existing `test_rotate_executor.py` cases that mock
+`_verify_playlist_size` (now removed) to mock `verify_playlist_state`.
+
+## Verification
+
+```bash
+flake8 shuffify/services/executors/rotate_executor.py
+pytest tests/services/executors/test_rotate_executor.py -v
+pytest tests/ -v
+```
+
+End-to-end:
+
+1. Construct a 10-track playlist with 5 locked + 5 unlocked.
+2. Run a rotation with `rotation_count=8`. `swap_in_uris` will be 8;
+   `swap_out_uris` will be capped at 5.
+3. Expected final size = 10 − 5 + 8 = 13.
+4. With F3 + F1, this passes verification. Without F3, F1 would raise because
+   it would have been told to expect 10.
+
+## Rollout note
+
+Ship in the same release as F1 (and ideally F2). F3 only fixes a baseline
+that nothing else looks at today — its value materializes once F1 is enforcing.

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/04_spotify_write_api.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/04_spotify_write_api.md
@@ -1,0 +1,264 @@
+# F4 — Tighten Spotify write-API contracts
+
+**Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Targets:** RC3 (shuffle multi-batch partial-write), RC4/RC5 (add/remove partial-write)
+**Risk:** Low. Effort: Medium.
+
+## Context
+
+The three Spotify-side write helpers swallow most failure information:
+
+- `update_playlist_tracks` (`spotify/api.py:336-385`) PUTs the first batch then
+  POSTs subsequent batches in a loop. The return value is `True` whether or not
+  later POSTs succeeded.
+- `playlist_add_items` (`spotify/api.py:427-460`) returns `None`. Callers can't
+  tell partial batches apart from full success.
+- `playlist_remove_items` (`spotify/api.py:462-508`) returns `True` regardless
+  of how many of the requested URIs actually got removed (Spotify silently
+  no-ops on missing URIs).
+- `_batch_add_tracks` (`base_executor.py:401-408`) calls `playlist_add_items`
+  and ignores the return value entirely.
+
+F1's verify wrapper catches the **outcome** of these failures, but F4 closes
+the gap at the **source** — the lowest layer raises so the diagnostic shows
+which batch failed, with what HTTP status. This makes Sentry events (F5)
+actionable and reduces the cases F1's expensive re-fetch has to handle.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `shuffify/spotify/api.py` | `update_playlist_tracks`, `playlist_add_items`, `playlist_remove_items` all return a structured result and raise on per-batch HTTP failure. Add a `SpotifyPartialBatchError` exception |
+| `shuffify/spotify/exceptions.py` | Add `SpotifyPartialBatchError(SpotifyAPIError)` |
+| `shuffify/spotify/http_client.py` | Verify that non-2xx already raises (it should, but confirm — see Investigation note below) |
+| `shuffify/services/executors/base_executor.py` | `_batch_add_tracks` consumes the return value and raises on shortfall |
+| `tests/spotify/test_api_write_contracts.py` | New test module |
+
+## Approach
+
+### A. New exception
+
+```python
+# shuffify/spotify/exceptions.py
+
+class SpotifyPartialBatchError(SpotifyAPIError):
+    """Raised when a multi-batch playlist write fails mid-flight.
+
+    Attributes:
+        playlist_id: Target playlist.
+        method: One of 'add', 'remove', 'update'.
+        completed_batches: Number of batches that succeeded.
+        total_batches: Total batches attempted.
+        completed_uris: URIs successfully written.
+        remaining_uris: URIs that were not written (or whose write
+            could not be confirmed).
+        cause: The underlying HTTP/Spotify error.
+    """
+```
+
+### B. `update_playlist_tracks` — per-batch try, raise on failure
+
+Current (`spotify/api.py:344-385`):
+```python
+# Replace first batch
+self._http.put(...)
+
+# Add remaining batches
+for i in range(self.BATCH_SIZE, len(track_uris), self.BATCH_SIZE):
+    batch = track_uris[i: i + self.BATCH_SIZE]
+    self._http.post(...)
+
+return True
+```
+
+New:
+```python
+completed: list[str] = []
+total_batches = (len(track_uris) + self.BATCH_SIZE - 1) // self.BATCH_SIZE
+
+# Batch 1: PUT (replaces playlist contents)
+first = track_uris[:self.BATCH_SIZE]
+try:
+    self._http.put(
+        f"/playlists/{playlist_id}/items",
+        json={"uris": first},
+    )
+except SpotifyAPIError as e:
+    raise SpotifyPartialBatchError(
+        playlist_id=playlist_id, method="update",
+        completed_batches=0, total_batches=total_batches,
+        completed_uris=[],
+        remaining_uris=list(track_uris),
+        cause=e,
+    )
+completed.extend(first)
+
+# Batches 2+: POST (append)
+for batch_idx, i in enumerate(
+    range(self.BATCH_SIZE, len(track_uris), self.BATCH_SIZE), start=1,
+):
+    batch = track_uris[i: i + self.BATCH_SIZE]
+    try:
+        self._http.post(
+            f"/playlists/{playlist_id}/items",
+            json={"uris": batch},
+        )
+    except SpotifyAPIError as e:
+        if self._cache:
+            self._cache.invalidate_playlist(playlist_id)
+        raise SpotifyPartialBatchError(
+            playlist_id=playlist_id, method="update",
+            completed_batches=batch_idx, total_batches=total_batches,
+            completed_uris=list(completed),
+            remaining_uris=list(track_uris[i:]),
+            cause=e,
+        )
+    completed.extend(batch)
+
+if self._cache:
+    self._cache.invalidate_playlist(playlist_id)
+    if self._user_id:
+        self._cache.invalidate_user_playlists(self._user_id)
+
+return completed
+```
+
+Return contract changes from `bool` to `list[str]` — the URIs actually written
+in order. Existing callers either:
+- discard the return (e.g., `shuffle_executor.py:157-159`) — unaffected, F1
+  drives verification;
+- use it as a truthy check — change to `len(result) == len(track_uris)`.
+
+### C. `playlist_add_items` — same pattern
+
+Today returns `None`. Change to return `list[str]` (URIs written), raise
+`SpotifyPartialBatchError` on per-batch failure.
+
+### D. `playlist_remove_items` — same pattern
+
+Spotify's DELETE silently no-ops on URIs not on the playlist. The HTTP layer
+can succeed without anything being removed. **Detecting that requires a
+post-write fetch**, which is exactly what F1 does. F4's job here is narrower:
+ensure HTTP-level failures raise `SpotifyPartialBatchError(method="remove")`.
+
+Do **not** try to detect "URI was on the playlist but didn't get removed" at
+this layer — that's F1's job. F4 only catches "HTTP request failed".
+
+### E. `_batch_add_tracks` (`base_executor.py:401-408`)
+
+Today:
+```python
+@staticmethod
+def _batch_add_tracks(
+    api: SpotifyAPI,
+    playlist_id: str,
+    uris: List[str],
+    batch_size: int = 100,
+) -> None:
+    api.playlist_add_items(playlist_id, uris)
+```
+
+New:
+```python
+@staticmethod
+def _batch_add_tracks(
+    api: SpotifyAPI,
+    playlist_id: str,
+    uris: List[str],
+    batch_size: int = 100,
+) -> list[str]:
+    written = api.playlist_add_items(playlist_id, uris) or []
+    if len(written) != len(uris):
+        raise SpotifyPartialBatchError(
+            playlist_id=playlist_id, method="add",
+            completed_batches=-1, total_batches=-1,
+            completed_uris=list(written),
+            remaining_uris=[u for u in uris if u not in set(written)],
+            cause=None,
+        )
+    return written
+```
+
+(`-1` sentinels for batch counts when we can't recover that detail from the
+wrapped call — `playlist_add_items` is where the real counters live.)
+
+### F. Verify `http_client.py` raises on non-2xx
+
+The repo notes that `SpotifyHTTPClient` has retry + rate-limit backoff. Before
+implementing F4, run a quick check:
+
+```bash
+grep -n "raise" shuffify/spotify/http_client.py
+grep -n "status_code" shuffify/spotify/http_client.py
+```
+
+Confirm that 4xx (other than 429 + 401-with-refresh) and 5xx (after retries
+exhausted) propagate as `SpotifyAPIError` / subclasses. The plan assumes they
+do; if not, fix that as part of F4 — without it, the catches above don't fire.
+
+## Tests (`tests/spotify/test_api_write_contracts.py`)
+
+Use `pytest-mock` (or `unittest.mock`) to patch `SpotifyHTTPClient`:
+
+```python
+def test_update_playlist_tracks_succeeds_returns_uris()
+def test_update_playlist_tracks_put_failure_raises_partial_batch()
+def test_update_playlist_tracks_first_post_failure_raises_partial_batch()
+def test_update_playlist_tracks_last_post_failure_raises_partial_batch()
+def test_update_playlist_tracks_invalidates_cache_on_failure()  # data already changed
+def test_playlist_add_items_succeeds_returns_uris()
+def test_playlist_add_items_mid_batch_failure_raises_partial_batch()
+def test_playlist_remove_items_http_failure_raises_partial_batch()
+def test_batch_add_tracks_propagates_partial_batch()
+def test_partial_batch_error_carries_completed_and_remaining_lists()
+```
+
+For each failure test, assert on `exc.completed_uris`, `exc.remaining_uris`,
+`exc.completed_batches`, `exc.total_batches`, and `isinstance(exc.cause, SpotifyAPIError)`.
+
+## Interaction with F1
+
+F1's verify still runs after the write. F4 makes the write **raise early** on
+HTTP failure — F1's verify would otherwise catch the same problem one round-trip
+later. Two reasons to keep both:
+
+1. F4 gives a precise diagnostic (which batch failed, with what HTTP status)
+   for Sentry (F5). F1 only sees "the playlist looks wrong".
+2. F4 doesn't cover Spotify side-effects that pass HTTP (e.g., silent
+   dedupe). F1 catches those.
+
+`PlaylistVerificationError` and `SpotifyPartialBatchError` are distinct types
+so F2's rollback handler (which catches `PlaylistVerificationError`) keeps
+its narrow scope. Should `SpotifyPartialBatchError` also trigger rollback?
+Yes — extend F2's handler:
+
+```python
+except (PlaylistVerificationError, SpotifyPartialBatchError) as e:
+    JobExecutorService._record_rollback(...)
+```
+
+Document this in F2 if F4 ships after F2.
+
+## Verification
+
+```bash
+flake8 shuffify/spotify/
+pytest tests/spotify/test_api_write_contracts.py -v
+pytest tests/ -v
+```
+
+Behavioral: in a preview deploy, simulate a 502 on the second POST of a
+multi-batch `update_playlist_tracks` by patching `_http.post` to raise on the
+second call. Expect `SpotifyPartialBatchError`, JobExecution `failed_rolled_back`
+(once F2 is wired), playlist restored from pre-snapshot.
+
+## Rollout note
+
+F4 can ship independently of F1/F2/F3 because today's callers ignore the
+return values — changing them from `bool`/`None` to `list[str]` is a strict
+superset. The new exceptions, however, will start firing where today's code
+silently continued. Tests on the executor side need to be updated to catch
+`SpotifyPartialBatchError` if they want to keep asserting "no exception".
+
+Recommended order: ship after F1+F2+F3 so the rollback path is in place when
+the new exceptions start surfacing in prod.

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/05_sentry_wiring.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/05_sentry_wiring.md
@@ -1,0 +1,211 @@
+# F5 — Wire up Sentry in production
+
+**Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Targets:** RC8 (no production observability)
+**Risk:** Low. Effort: Small.
+
+## Context
+
+`sentry-sdk>=2.58.0,<3.0` is already in `requirements/prod.txt:4` but is
+**never imported or initialized** anywhere in the codebase (grep confirms
+zero references outside requirements). `SENTRY_DSN` is not set in the DO
+app spec. The DO log buffer is small, so historical loss events age out —
+we can't tell how many WOOKLYN rotations have already silently failed.
+
+This fix wires Sentry into the Flask app factory with Flask + APScheduler +
+logging integrations, captures executor warnings (the existing
+`rotate_executor.py:248-252` warning becomes a real event), and tags every
+event with `schedule_id`, `playlist_id`, `job_type`, and `user_id` for
+filtering.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `config.py` | Add `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE` to `Config` and `ProductionConfig` |
+| `shuffify/__init__.py` | Initialize Sentry in `create_app` **before** any other extension setup |
+| `shuffify/services/executors/base_executor.py` | In `_record_failure` and `_record_rollback` (F2), set Sentry scope tags |
+| `documentation/production-database-setup.md` (or new doc) | Note Sentry DSN procurement & env-var name |
+| `tests/test_sentry_init.py` | New test asserting graceful no-op when DSN is empty |
+
+No code change is required in the executors themselves — the LoggingIntegration
+captures `logger.warning(...)` calls at the configured threshold automatically.
+
+## Approach
+
+### A. Config
+
+```python
+# config.py — add to Config (or ProductionConfig if you want dev-off by default):
+
+SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "production")
+SENTRY_TRACES_SAMPLE_RATE = float(
+    os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0")
+)
+SENTRY_PROFILES_SAMPLE_RATE = float(
+    os.environ.get("SENTRY_PROFILES_SAMPLE_RATE", "0.0")
+)
+```
+
+Tracing/profiling default off — Shuffify's traffic is low and we want this
+fix to add zero perf risk. Errors + warnings come for free at any sample rate.
+
+### B. Init in app factory
+
+In `shuffify/__init__.py`'s `create_app` (or wherever the factory lives),
+**before** Flask, db, scheduler, etc.:
+
+```python
+import logging
+
+def create_app(config_name="production"):
+    config_class = _select_config(config_name)
+    dsn = getattr(config_class, "SENTRY_DSN", "") or ""
+    if dsn:
+        import sentry_sdk
+        from sentry_sdk.integrations.flask import FlaskIntegration
+        from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+        from sentry_sdk.integrations.logging import LoggingIntegration
+
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=config_class.SENTRY_ENVIRONMENT,
+            traces_sample_rate=config_class.SENTRY_TRACES_SAMPLE_RATE,
+            profiles_sample_rate=config_class.SENTRY_PROFILES_SAMPLE_RATE,
+            send_default_pii=False,
+            integrations=[
+                FlaskIntegration(),
+                SqlalchemyIntegration(),
+                LoggingIntegration(
+                    level=logging.INFO,         # breadcrumbs at INFO
+                    event_level=logging.WARNING, # capture WARN+ as events
+                ),
+            ],
+            release=_resolve_git_sha() or None,
+            before_send=_strip_pii,
+        )
+
+    app = Flask(__name__)
+    ...
+```
+
+`_resolve_git_sha`: read `GIT_SHA` env var (set in DO spec) or `git rev-parse`
+in dev. `_strip_pii`: drop Spotify access tokens, encrypted refresh tokens,
+session cookies from event extra/headers. Implement as a small helper that
+walks `event.get("request", {}).get("headers", {})` and `event.get("extra", {})`
+and redacts known keys.
+
+### C. APScheduler context
+
+Background jobs run outside the Flask request context. The `LoggingIntegration`
+still works (logger events flow up to Sentry), but to **tag** scheduled jobs
+properly, wrap the job-dispatch path:
+
+```python
+# In JobExecutorService.execute (base_executor.py:40), at the top:
+import sentry_sdk
+
+with sentry_sdk.configure_scope() as scope:
+    scope.set_tag("schedule_id", schedule_id)
+    if schedule:
+        scope.set_tag("job_type", str(schedule.job_type))
+        scope.set_tag("playlist_id", schedule.target_playlist_id)
+        scope.set_user({"id": str(schedule.user_id)})
+    # ...rest of execute
+```
+
+This makes Sentry's UI filterable by schedule, job type, playlist, and user.
+Critical for finding the next WOOKLYN-class incident.
+
+### D. Capture the existing warning
+
+`rotate_executor.py:248-252`:
+
+```python
+logger.warning(
+    "Schedule %s: %s size mismatch — expected %d tracks, got %d",
+    schedule_id, phase, expected, actual,
+)
+```
+
+With `LoggingIntegration(event_level=logging.WARNING)`, this becomes a Sentry
+event automatically. After F1 ships, the warning is replaced by
+`PlaylistVerificationError` (an exception) which Sentry captures as an
+**error** event with full traceback — even better.
+
+### E. DO app spec env
+
+User action (not a code change):
+
+```bash
+doctl apps spec get 1ac416ce-832e-4f93-bcef-f0624c5f81c5 > do_spec.yaml
+# Add under envs:
+# - key: SENTRY_DSN
+#   value: <from Sentry project settings>
+#   type: SECRET
+# - key: SENTRY_ENVIRONMENT
+#   value: production
+doctl apps update 1ac416ce-832e-4f93-bcef-f0624c5f81c5 --spec do_spec.yaml
+```
+
+(The DSN value is procured from the Sentry project's Client Keys page. **Do
+not paste the actual DSN into this doc, the PR, or commit it to env files.**)
+
+### F. PII handling
+
+The Shuffify model includes encrypted refresh tokens and email addresses on
+`User`. The `before_send` filter must:
+
+- Strip `Authorization` / `Cookie` headers from any request payload.
+- Strip the `session` extras.
+- Replace `user.email` with a hash if it leaks into an event.
+
+Recommended implementation: keep a denylist of substrings (e.g., `"refresh_token"`,
+`"access_token"`, `"encrypted_"`, `"email"`) and redact any dict value whose
+key matches.
+
+## Tests (`tests/test_sentry_init.py`)
+
+```python
+def test_create_app_with_empty_dsn_does_not_init():
+    """Empty/missing DSN must skip sentry_sdk.init."""
+
+def test_create_app_with_dsn_calls_init(monkeypatch):
+    """Patched sentry_sdk.init is invoked with expected kwargs."""
+
+def test_before_send_strips_known_pii_keys():
+    """before_send filter redacts refresh_token, access_token, etc."""
+
+def test_before_send_passes_clean_events_through():
+```
+
+We do not need to call the real Sentry network from tests — patch `sentry_sdk`
+in pytest.
+
+## Verification
+
+```bash
+flake8 shuffify/__init__.py
+pytest tests/test_sentry_init.py -v
+```
+
+Behavioral, post-deploy:
+
+1. Trigger a deliberate executor warning (e.g., `flask shell` and call
+   `logger.warning("test sentry capture")` from `shuffify.services.executors.rotate_executor`).
+2. Confirm an event appears in the Sentry project within ~1 minute,
+   tagged with the right environment.
+3. After F1+F2 ship, trigger a synthetic `PlaylistVerificationError` and
+   confirm it lands in Sentry with `schedule_id`/`playlist_id` tags.
+
+## Rollout note
+
+F5 is decoupled from F1-F4 and can ship first if desired — it makes the
+**current** silent-loss class louder right now, even before the verifier
+lands. Recommended order in `00_INVESTIGATION.md` puts F5 last only because
+F1's exception is a more informative event than today's warning; but shipping
+F5 first means we'll have observability while the other PRs are reviewed.
+
+The DO env-var change is the user's responsibility; it does not require a
+redeploy beyond the next push.

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/06_neon_forensic_sql.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/06_neon_forensic_sql.md
@@ -1,0 +1,315 @@
+# F6 — Neon forensic SQL for WOOKLYN loss timeline
+
+**Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Status:** IN PROGRESS — Started 2026-05-16
+**Targets:** "What has WOOKLYN actually lost, and which snapshot do I restore from?"
+**Risk:** None — read-only SQL. Effort: Small.
+
+## Implementation decisions (2026-05-16)
+
+- **Broader playlist match.** Resolve `(user_id, playlist_id)` candidates via
+  the union of: (a) `schedules` rows whose `target_playlist_name` matches the
+  pattern, and (b) `playlist_snapshots` rows whose `playlist_name` matches.
+  This catches playlists that were renamed mid-history — the snapshot table
+  stores the name at-snapshot, so it preserves prior names.
+- **Parameterized time window.** Default 60 days, override via
+  `-v days_back=365`. Keeps the default query fast while supporting wider
+  sweeps when needed.
+- **Restore quick-card section.** A final section emits a one-row "this is the
+  snapshot to restore from right now" answer with the exact `flask shell`
+  snippet to apply it. Each numbered section is its own CTE so they can be
+  run in isolation while iterating.
+
+## Context
+
+We have one direct piece of evidence — the `2026-05-13` DigitalOcean warning
+about Schedule 11. Everything else is hypothesis. Before any code change ships,
+we need to confirm the scope of damage in Neon:
+
+- How many WOOKLYN rotations have run?
+- For each run: did the executor claim success? What were `tracks_added` /
+  `tracks_total`?
+- How does the pre-snapshot track count compare to the post-run reported
+  total?
+- Which snapshot is the most-recent intact version of WOOKLYN, and what's its
+  ID for restoration?
+
+This fix is **purely operational** — a SQL script + a documented run procedure.
+No application code changes.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `scripts/forensics/wooklyn_loss_timeline.sql` | New file — the query (parameterized on playlist name) |
+| `scripts/forensics/README.md` | New — run instructions, expected output, how to act on results |
+
+Note: `scripts/` already exists in the repo (per the `gitStatus` at session
+start). Place `forensics/` as a subdirectory there.
+
+## Query
+
+```sql
+-- scripts/forensics/wooklyn_loss_timeline.sql
+--
+-- Read-only forensic timeline for any playlist matched by name.
+-- Joins schedules × job_executions × playlist_snapshots × activity_log.
+--
+-- Parameter:
+--   :playlist_name_pattern (e.g., '%WOOKLYN%')
+--
+-- Usage (psql, read-only, with statement_timeout):
+--   psql "$DATABASE_URL" \
+--     -v playlist_name_pattern="'%WOOKLYN%'" \
+--     -f scripts/forensics/wooklyn_loss_timeline.sql
+
+\set ON_ERROR_STOP on
+SET default_transaction_read_only = on;
+SET statement_timeout = '60s';
+
+-- 1) Identify the playlist(s) and their schedules.
+\echo '== Schedules targeting playlists matching pattern =='
+SELECT
+    s.id              AS schedule_id,
+    s.user_id,
+    s.job_type,
+    s.target_playlist_id,
+    s.target_playlist_name,
+    s.algorithm_params,
+    s.is_enabled,
+    s.last_run_at,
+    s.last_status,
+    s.last_error
+FROM schedules s
+WHERE s.target_playlist_name ILIKE :playlist_name_pattern
+ORDER BY s.last_run_at DESC NULLS LAST;
+
+-- 2) Job execution history for those schedules (last 60 days).
+\echo
+\echo '== Recent job executions =='
+WITH matched_schedules AS (
+    SELECT id, user_id, target_playlist_id, target_playlist_name
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+)
+SELECT
+    je.id              AS execution_id,
+    ms.target_playlist_name,
+    je.schedule_id,
+    je.status,
+    je.started_at,
+    je.completed_at,
+    je.tracks_added,
+    je.tracks_total,
+    EXTRACT(EPOCH FROM (je.completed_at - je.started_at))::int
+                        AS duration_seconds,
+    LEFT(je.error_message, 200) AS error_message_preview
+FROM job_executions je
+JOIN matched_schedules ms ON ms.id = je.schedule_id
+WHERE je.started_at >= NOW() - INTERVAL '60 days'
+ORDER BY je.started_at DESC;
+
+-- 3) Snapshot timeline with track counts (last 60 days).
+\echo
+\echo '== Snapshot timeline =='
+WITH matched_playlists AS (
+    SELECT DISTINCT user_id, target_playlist_id AS playlist_id
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+)
+SELECT
+    ps.id              AS snapshot_id,
+    ps.user_id,
+    ps.playlist_id,
+    ps.playlist_name,
+    ps.snapshot_type,
+    ps.trigger_description,
+    ps.track_count,
+    ps.created_at
+FROM playlist_snapshots ps
+JOIN matched_playlists mp
+  ON mp.user_id = ps.user_id
+ AND mp.playlist_id = ps.playlist_id
+WHERE ps.created_at >= NOW() - INTERVAL '60 days'
+ORDER BY ps.created_at DESC;
+
+-- 4) Activity log entries (last 60 days).
+\echo
+\echo '== Activity log =='
+WITH matched_playlists AS (
+    SELECT DISTINCT user_id, target_playlist_id AS playlist_id
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+)
+SELECT
+    al.id,
+    al.activity_type,
+    LEFT(al.description, 200) AS description_preview,
+    al.metadata_json,
+    al.created_at
+FROM activity_log al
+JOIN matched_playlists mp
+  ON mp.user_id = al.user_id
+ AND mp.playlist_id = al.playlist_id
+WHERE al.created_at >= NOW() - INTERVAL '60 days'
+ORDER BY al.created_at DESC;
+
+-- 5) Loss reconstruction — pair each execution with the
+--    snapshot taken closest before it (the "pre" snapshot) and
+--    the next snapshot taken after it (the "post" if auto-snapshot
+--    on the next rotation captured a hint).
+\echo
+\echo '== Pre/post snapshot pairing per execution =='
+WITH matched_playlists AS (
+    SELECT id              AS schedule_id,
+           user_id,
+           target_playlist_id AS playlist_id,
+           target_playlist_name
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+),
+exec_with_pre AS (
+    SELECT
+        je.id                                    AS execution_id,
+        je.schedule_id,
+        je.status,
+        je.started_at,
+        je.tracks_total                          AS reported_total,
+        mp.user_id,
+        mp.playlist_id,
+        mp.target_playlist_name,
+        (SELECT ps.id
+           FROM playlist_snapshots ps
+          WHERE ps.user_id = mp.user_id
+            AND ps.playlist_id = mp.playlist_id
+            AND ps.created_at <= je.started_at
+          ORDER BY ps.created_at DESC
+          LIMIT 1)                              AS pre_snapshot_id,
+        (SELECT ps.track_count
+           FROM playlist_snapshots ps
+          WHERE ps.user_id = mp.user_id
+            AND ps.playlist_id = mp.playlist_id
+            AND ps.created_at <= je.started_at
+          ORDER BY ps.created_at DESC
+          LIMIT 1)                              AS pre_count,
+        (SELECT ps.track_count
+           FROM playlist_snapshots ps
+          WHERE ps.user_id = mp.user_id
+            AND ps.playlist_id = mp.playlist_id
+            AND ps.created_at >= je.completed_at
+          ORDER BY ps.created_at ASC
+          LIMIT 1)                              AS next_snapshot_count
+    FROM job_executions je
+    JOIN matched_playlists mp ON mp.schedule_id = je.schedule_id
+    WHERE je.started_at >= NOW() - INTERVAL '60 days'
+)
+SELECT
+    started_at,
+    target_playlist_name,
+    execution_id,
+    status,
+    pre_count,
+    reported_total,
+    next_snapshot_count,
+    (next_snapshot_count - pre_count) AS drift_pre_to_next,
+    pre_snapshot_id                   AS restore_from_snapshot_id
+FROM exec_with_pre
+ORDER BY started_at DESC;
+
+-- 6) Best snapshot to restore from now.
+\echo
+\echo '== Most recent intact snapshot per matched playlist =='
+WITH matched_playlists AS (
+    SELECT DISTINCT user_id,
+                    target_playlist_id AS playlist_id,
+                    target_playlist_name
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+)
+SELECT DISTINCT ON (ps.playlist_id)
+    mp.target_playlist_name,
+    ps.id            AS snapshot_id,
+    ps.snapshot_type,
+    ps.track_count,
+    ps.created_at
+FROM playlist_snapshots ps
+JOIN matched_playlists mp
+  ON mp.user_id = ps.user_id
+ AND mp.playlist_id = ps.playlist_id
+ORDER BY ps.playlist_id, ps.created_at DESC;
+```
+
+## Companion script (optional but useful)
+
+```bash
+# scripts/forensics/run_wooklyn_timeline.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATTERN="${1:-%WOOKLYN%}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    echo "DATABASE_URL not set. Source from .env or DO app spec first." >&2
+    exit 1
+fi
+
+psql "$DATABASE_URL" \
+    -v ON_ERROR_STOP=1 \
+    -v playlist_name_pattern="'${PATTERN}'" \
+    -f "$(dirname "$0")/wooklyn_loss_timeline.sql"
+```
+
+Make executable, document in `scripts/forensics/README.md`. Pulling
+`DATABASE_URL` from Neon's pooled connection string (read-only role
+preferred) is the safest route.
+
+## Expected output shape
+
+For each section the script prints a header (`\echo`) followed by a table.
+Reading order:
+
+1. **Schedules** — confirm WOOKLYN's `schedule_id`. We expect Schedule 11
+   (per the DO log).
+2. **Job executions** — count of `success` vs `failed` runs in the last 60
+   days, plus reported `tracks_total` per run.
+3. **Snapshots** — count of `auto_pre_rotate` rows. Compare track counts
+   across successive snapshots to spot losses.
+4. **Activity log** — verify `SCHEDULE_RUN` entries align with executions.
+5. **Pre/post pairing** — the key correlation: `pre_count` vs
+   `next_snapshot_count`. Any negative `drift_pre_to_next` is a silent loss.
+6. **Most recent intact snapshot** — `restore_from_snapshot_id` ready to feed
+   into the UI's snapshot-restore flow or a direct API call.
+
+## Acting on results
+
+If section (5) shows a string of `drift_pre_to_next < 0` rows, the silent-loss
+hypothesis is confirmed at scale and F1+F2 are urgent. If only one or two rows
+show drift, the 5/13 incident is plausibly isolated — F1+F2 still ship to
+prevent recurrence, but the rollout is less time-pressured.
+
+If the user wants to restore WOOKLYN to its most-recent intact state right
+now, use the `snapshot_id` from section (6) and the existing snapshot-restore
+UI (or call `PlaylistSnapshotService.restore_snapshot` + `api.update_playlist_tracks`
+manually via `flask shell`).
+
+## Verification
+
+Read-only sanity:
+
+```bash
+psql "$DATABASE_URL" \
+    -v ON_ERROR_STOP=1 \
+    -v playlist_name_pattern="'%nonexistent_playlist_name%'" \
+    -f scripts/forensics/wooklyn_loss_timeline.sql
+```
+
+Expect zero rows in every section — confirms no side effects, query is safe
+to run in production.
+
+Then run with `%WOOKLYN%` and inspect.
+
+## Rollout note
+
+Ship before the code fixes — this query is the source of truth for **what
+has already happened**, which informs urgency on F1/F2 rollout. It introduces
+no code-path risk (read-only) so it can land as soon as it's reviewed.

--- a/scripts/forensics/README.md
+++ b/scripts/forensics/README.md
@@ -1,0 +1,102 @@
+# Forensic scripts
+
+Read-only SQL scripts for reconstructing silent state-loss timelines.
+
+## `wooklyn_loss_timeline.sql`
+
+Forensic reconstruction for any playlist matched by name. Joins
+`schedules × job_executions × playlist_snapshots × activity_log` and emits
+seven sections covering matched-playlist resolution, schedule config, run
+history, snapshot timeline, activity log, per-run drift detection, and a
+final restore quick-card.
+
+Originally written to investigate silent track losses on the WOOKLYN
+playlist (see
+`documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/`),
+but the pattern parameter makes it reusable for any playlist by name.
+
+### Safety
+
+Every run starts with:
+
+```sql
+SET default_transaction_read_only = on;
+SET statement_timeout = '60s';
+```
+
+The script makes no writes. It cannot be repurposed to mutate state without
+removing those `SET` statements. The 60s timeout prevents accidental load
+on the production database.
+
+### Running it
+
+```bash
+# Default pattern + window
+./scripts/forensics/run_wooklyn_timeline.sh
+
+# Custom pattern
+./scripts/forensics/run_wooklyn_timeline.sh '%my-playlist%'
+
+# Custom pattern + 1-year window
+./scripts/forensics/run_wooklyn_timeline.sh '%my-playlist%' 365
+```
+
+Or invoke `psql` directly:
+
+```bash
+psql "$DATABASE_URL" \
+    -v ON_ERROR_STOP=1 \
+    -v playlist_name_pattern="'%WOOKLYN%'" \
+    -v days_back=60 \
+    -f scripts/forensics/wooklyn_loss_timeline.sql
+```
+
+`DATABASE_URL` must be sourced from `.env` or the DigitalOcean app spec
+before running. A read-only role is recommended even though the script
+self-enforces read-only.
+
+### Output sections
+
+| # | Section | What it tells you |
+|---|---------|-------------------|
+| 1 | Matched playlists | Which `(user_id, playlist_id)` pairs the pattern resolved — useful when a playlist was renamed mid-history |
+| 2 | Schedules | Every schedule targeting a matched playlist, with its current state |
+| 3 | Job executions | Run history with executor-reported `tracks_added` and `tracks_total` |
+| 4 | Snapshots | Snapshot timeline with stored `track_count` per row |
+| 5 | Activity log | `SCHEDULE_RUN` and related entries, with `metadata_json` payloads |
+| 6 | Loss reconstruction | The detector: `drift_pre_to_next < 0` means tracks were lost across that run |
+| 7 | Restore quick-card | One row per playlist with the snapshot id ready to restore |
+
+### Interpreting drift
+
+Section 6's `drift_pre_to_next` column is the key signal:
+
+- `0` or `NULL`: no drift detectable from snapshots (run was either correct, or no snapshot was taken on the next operation)
+- `> 0`: playlist grew (raid/drip behaved as expected)
+- `< 0`: playlist shrunk between snapshots — **silent track loss**
+
+A run can claim `status='success'` and still show `drift < 0`. That is the
+exact bug class this script was written to surface.
+
+### Acting on results
+
+If section 6 shows a string of negative drift rows: the silent-loss
+hypothesis is confirmed at scale and the F1+F2 fixes
+(`01_verify_wrapper.md`, `02_snapshot_rollback.md`) are urgent.
+
+Use section 7's `snapshot_id` with the existing snapshot-restore UI or
+manually via `flask shell`:
+
+```python
+from shuffify.services.playlist_snapshot_service import (
+    PlaylistSnapshotService,
+)
+from shuffify.spotify.api import SpotifyAPI
+# (instantiate api as in JobExecutorService._get_spotify_api)
+
+uris = PlaylistSnapshotService.restore_snapshot(<snapshot_id>, <user_id>)
+api.update_playlist_tracks("<playlist_id>", uris)
+```
+
+The `flask_shell_command_hint` column in section 7 emits a paste-ready
+template per playlist.

--- a/scripts/forensics/run_wooklyn_timeline.sh
+++ b/scripts/forensics/run_wooklyn_timeline.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run the WOOKLYN forensic timeline query against Neon.
+#
+# Usage:
+#   ./run_wooklyn_timeline.sh                 # pattern '%WOOKLYN%', 60 days
+#   ./run_wooklyn_timeline.sh '%my-playlist%' # custom pattern, 60 days
+#   ./run_wooklyn_timeline.sh '%WOOKLYN%' 365 # custom pattern + window
+#
+# Requires DATABASE_URL in the environment (export it from .env or DO).
+set -euo pipefail
+
+PATTERN="${1:-%WOOKLYN%}"
+DAYS_BACK="${2:-60}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    echo "DATABASE_URL not set." >&2
+    echo "Source it from .env or DO app spec before running, e.g.:" >&2
+    echo "    export DATABASE_URL=\"<neon connection string>\"" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+psql "$DATABASE_URL" \
+    -v ON_ERROR_STOP=1 \
+    -v playlist_name_pattern="'${PATTERN}'" \
+    -v days_back="${DAYS_BACK}" \
+    -f "${SCRIPT_DIR}/wooklyn_loss_timeline.sql"

--- a/scripts/forensics/wooklyn_loss_timeline.sql
+++ b/scripts/forensics/wooklyn_loss_timeline.sql
@@ -1,0 +1,305 @@
+-- wooklyn_loss_timeline.sql
+--
+-- Forensic timeline for any playlist matched by name. Joins
+--   schedules
+--   × job_executions
+--   × playlist_snapshots
+--   × activity_log
+-- to reconstruct what each rotation/raid/shuffle job claimed vs. what
+-- the next snapshot observed, surfacing silent track losses.
+--
+-- Read-only. Enforces SET default_transaction_read_only and a
+-- statement_timeout so accidental runs cannot impact production.
+--
+-- Parameters (set via psql -v):
+--   playlist_name_pattern : ILIKE pattern, e.g. '%WOOKLYN%' (REQUIRED)
+--   days_back             : history window in days, default 60
+--
+-- Usage:
+--   psql "$DATABASE_URL" \
+--     -v ON_ERROR_STOP=1 \
+--     -v playlist_name_pattern="'%WOOKLYN%'" \
+--     -v days_back=60 \
+--     -f scripts/forensics/wooklyn_loss_timeline.sql
+--
+-- The matched-playlist resolution UNIONs schedule names and
+-- snapshot names so playlists renamed mid-history still surface.
+--
+-- See scripts/forensics/README.md for output interpretation.
+
+\set ON_ERROR_STOP on
+SET default_transaction_read_only = on;
+SET statement_timeout = '60s';
+
+-- Default days_back when not provided.
+\if :{?days_back}
+\else
+    \set days_back 60
+\endif
+
+-- 1) Matched playlists (name match across schedules + snapshots).
+\echo '== 1. Matched playlists =='
+WITH matched_from_schedules AS (
+    SELECT DISTINCT
+        user_id,
+        target_playlist_id      AS playlist_id,
+        target_playlist_name    AS observed_name
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+),
+matched_from_snapshots AS (
+    SELECT DISTINCT
+        user_id,
+        playlist_id,
+        playlist_name           AS observed_name
+    FROM playlist_snapshots
+    WHERE playlist_name ILIKE :playlist_name_pattern
+)
+SELECT user_id, playlist_id, observed_name, 'schedule' AS source
+FROM matched_from_schedules
+UNION
+SELECT user_id, playlist_id, observed_name, 'snapshot' AS source
+FROM matched_from_snapshots
+ORDER BY playlist_id, source;
+
+-- 2) Schedules targeting any matched playlist.
+\echo
+\echo '== 2. Schedules =='
+WITH matched_playlists AS (
+    SELECT user_id, target_playlist_id AS playlist_id
+      FROM schedules
+     WHERE target_playlist_name ILIKE :playlist_name_pattern
+    UNION
+    SELECT user_id, playlist_id
+      FROM playlist_snapshots
+     WHERE playlist_name ILIKE :playlist_name_pattern
+)
+SELECT
+    s.id              AS schedule_id,
+    s.user_id,
+    s.job_type,
+    s.target_playlist_id,
+    s.target_playlist_name,
+    s.algorithm_params,
+    s.is_enabled,
+    s.last_run_at,
+    s.last_status,
+    s.last_error
+FROM schedules s
+JOIN matched_playlists mp
+  ON mp.user_id = s.user_id
+ AND mp.playlist_id = s.target_playlist_id
+ORDER BY s.last_run_at DESC NULLS LAST;
+
+-- 3) Job execution history within the window.
+\echo
+\echo '== 3. Job executions (within window) =='
+WITH matched_schedules AS (
+    SELECT s.id
+    FROM schedules s
+    WHERE EXISTS (
+        SELECT 1 FROM schedules s2
+        WHERE s2.id = s.id
+          AND s2.target_playlist_name ILIKE :playlist_name_pattern
+    )
+    OR EXISTS (
+        SELECT 1 FROM playlist_snapshots ps
+        WHERE ps.user_id = s.user_id
+          AND ps.playlist_id = s.target_playlist_id
+          AND ps.playlist_name ILIKE :playlist_name_pattern
+    )
+)
+SELECT
+    je.id              AS execution_id,
+    je.schedule_id,
+    je.status,
+    je.started_at,
+    je.completed_at,
+    je.tracks_added,
+    je.tracks_total,
+    EXTRACT(EPOCH FROM (je.completed_at - je.started_at))::int
+                       AS duration_seconds,
+    LEFT(je.error_message, 200) AS error_message_preview
+FROM job_executions je
+JOIN matched_schedules ms ON ms.id = je.schedule_id
+WHERE je.started_at >= NOW() - (INTERVAL '1 day' * :days_back)
+ORDER BY je.started_at DESC;
+
+-- 4) Snapshot timeline within the window.
+\echo
+\echo '== 4. Snapshots (within window) =='
+WITH matched_playlists AS (
+    SELECT DISTINCT user_id, target_playlist_id AS playlist_id
+      FROM schedules
+     WHERE target_playlist_name ILIKE :playlist_name_pattern
+    UNION
+    SELECT DISTINCT user_id, playlist_id
+      FROM playlist_snapshots
+     WHERE playlist_name ILIKE :playlist_name_pattern
+)
+SELECT
+    ps.id              AS snapshot_id,
+    ps.user_id,
+    ps.playlist_id,
+    ps.playlist_name,
+    ps.snapshot_type,
+    LEFT(ps.trigger_description, 100) AS trigger_preview,
+    ps.track_count,
+    ps.created_at
+FROM playlist_snapshots ps
+JOIN matched_playlists mp
+  ON mp.user_id = ps.user_id
+ AND mp.playlist_id = ps.playlist_id
+WHERE ps.created_at >= NOW() - (INTERVAL '1 day' * :days_back)
+ORDER BY ps.created_at DESC;
+
+-- 5) Activity log entries within the window.
+\echo
+\echo '== 5. Activity log (within window) =='
+WITH matched_playlists AS (
+    SELECT DISTINCT user_id, target_playlist_id AS playlist_id
+      FROM schedules
+     WHERE target_playlist_name ILIKE :playlist_name_pattern
+    UNION
+    SELECT DISTINCT user_id, playlist_id
+      FROM playlist_snapshots
+     WHERE playlist_name ILIKE :playlist_name_pattern
+)
+SELECT
+    al.id,
+    al.activity_type,
+    LEFT(al.description, 200) AS description_preview,
+    al.metadata_json,
+    al.created_at
+FROM activity_log al
+JOIN matched_playlists mp
+  ON mp.user_id = al.user_id
+ AND mp.playlist_id = al.playlist_id
+WHERE al.created_at >= NOW() - (INTERVAL '1 day' * :days_back)
+ORDER BY al.created_at DESC;
+
+-- 6) Per-execution pre/post snapshot pairing — the silent-loss detector.
+--    For each execution, find the snapshot taken just before it
+--    (pre_count) and the next snapshot taken after it (next_count).
+--    drift_pre_to_next < 0 indicates tracks lost across the run.
+\echo
+\echo '== 6. Loss reconstruction (drift < 0 = silent loss) =='
+WITH matched_playlists AS (
+    SELECT
+        s.id                     AS schedule_id,
+        s.user_id,
+        s.target_playlist_id     AS playlist_id,
+        s.target_playlist_name
+    FROM schedules s
+    WHERE s.target_playlist_name ILIKE :playlist_name_pattern
+       OR EXISTS (
+           SELECT 1 FROM playlist_snapshots ps
+           WHERE ps.user_id = s.user_id
+             AND ps.playlist_id = s.target_playlist_id
+             AND ps.playlist_name ILIKE :playlist_name_pattern
+       )
+)
+SELECT
+    je.started_at,
+    mp.target_playlist_name,
+    je.id                              AS execution_id,
+    je.status,
+    je.tracks_added,
+    je.tracks_total                    AS reported_total,
+    (
+        SELECT ps.track_count
+          FROM playlist_snapshots ps
+         WHERE ps.user_id = mp.user_id
+           AND ps.playlist_id = mp.playlist_id
+           AND ps.created_at <= je.started_at
+         ORDER BY ps.created_at DESC
+         LIMIT 1
+    )                                  AS pre_count,
+    (
+        SELECT ps.track_count
+          FROM playlist_snapshots ps
+         WHERE ps.user_id = mp.user_id
+           AND ps.playlist_id = mp.playlist_id
+           AND ps.created_at >= je.completed_at
+         ORDER BY ps.created_at ASC
+         LIMIT 1
+    )                                  AS next_count,
+    (
+        SELECT ps.track_count
+          FROM playlist_snapshots ps
+         WHERE ps.user_id = mp.user_id
+           AND ps.playlist_id = mp.playlist_id
+           AND ps.created_at >= je.completed_at
+         ORDER BY ps.created_at ASC
+         LIMIT 1
+    ) -
+    (
+        SELECT ps.track_count
+          FROM playlist_snapshots ps
+         WHERE ps.user_id = mp.user_id
+           AND ps.playlist_id = mp.playlist_id
+           AND ps.created_at <= je.started_at
+         ORDER BY ps.created_at DESC
+         LIMIT 1
+    )                                  AS drift_pre_to_next,
+    (
+        SELECT ps.id
+          FROM playlist_snapshots ps
+         WHERE ps.user_id = mp.user_id
+           AND ps.playlist_id = mp.playlist_id
+           AND ps.created_at <= je.started_at
+         ORDER BY ps.created_at DESC
+         LIMIT 1
+    )                                  AS pre_snapshot_id
+FROM job_executions je
+JOIN matched_playlists mp ON mp.schedule_id = je.schedule_id
+WHERE je.started_at >= NOW() - (INTERVAL '1 day' * :days_back)
+ORDER BY je.started_at DESC;
+
+-- 7) Restore quick-card — the most recent snapshot per matched
+--    playlist, with the flask-shell command to re-apply it.
+\echo
+\echo '== 7. Restore quick-card =='
+WITH matched_playlists AS (
+    SELECT DISTINCT
+        user_id,
+        target_playlist_id AS playlist_id,
+        target_playlist_name AS playlist_name
+    FROM schedules
+    WHERE target_playlist_name ILIKE :playlist_name_pattern
+    UNION
+    SELECT DISTINCT user_id, playlist_id, playlist_name
+    FROM playlist_snapshots
+    WHERE playlist_name ILIKE :playlist_name_pattern
+),
+latest AS (
+    SELECT DISTINCT ON (ps.playlist_id)
+        mp.playlist_name        AS target_playlist_name,
+        ps.id                   AS snapshot_id,
+        ps.user_id,
+        ps.playlist_id,
+        ps.snapshot_type,
+        ps.track_count,
+        ps.created_at
+    FROM playlist_snapshots ps
+    JOIN matched_playlists mp
+      ON mp.user_id = ps.user_id
+     AND mp.playlist_id = ps.playlist_id
+    ORDER BY ps.playlist_id, ps.created_at DESC
+)
+SELECT
+    target_playlist_name,
+    snapshot_id,
+    user_id,
+    playlist_id,
+    snapshot_type,
+    track_count,
+    created_at,
+    'PlaylistSnapshotService.restore_to_playlist('
+        || snapshot_id::text
+        || ', user_id='
+        || user_id::text
+        || ', api=<spotify api>)'
+                                AS flask_shell_command_hint
+FROM latest
+ORDER BY target_playlist_name;


### PR DESCRIPTION
## Summary

First PR in the WOOKLYN silent-loss investigation
(`documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/`).

Ships the investigation directory (7 planning docs) and the first
deliverable — **F6: a read-only forensic SQL script** for
reconstructing playlist track-loss history.

### Context

DigitalOcean runtime logs captured this on 2026-05-13 09:00:09 UTC:

```
WARNI [shuffify.services.executors.rotate_executor]
Schedule 11: swap size mismatch — expected 241 tracks, got 240
```

`rotate_executor._verify_playlist_size` only **raises** when drift
exceeds 50% of expected; smaller drifts log a warning and the job is
marked `success`. Shuffle / drip / raid have **no** post-write
verification at all. Snapshots are taken before every write
(`_auto_snapshot_before_*`) but no executor restores from them on
failure.

This PR doesn't fix the bugs — it gives us the read-only diagnostic
needed to quantify them before code changes ship (F1+F3 next, then F2,
F4, F5).

### What the script produces

Seven sections, each its own CTE so they can be run in isolation:

1. **Matched playlists** — `(user_id, playlist_id)` candidates resolved via UNION of `schedules.target_playlist_name` and `playlist_snapshots.playlist_name` (catches renamed playlists)
2. **Schedules** — every schedule targeting a matched playlist
3. **Job executions** — run history with executor-claimed `tracks_added`/`tracks_total`
4. **Snapshots** — timeline with stored `track_count`
5. **Activity log** — `SCHEDULE_RUN` entries with `metadata_json`
6. **Loss reconstruction** — drift detector: `drift_pre_to_next < 0` = silent loss
7. **Restore quick-card** — the snapshot to restore from right now, with a paste-ready `flask_shell` template

### Safety

- `SET default_transaction_read_only = on` — writes rejected (verified by attempting an UPDATE: `ERROR: cannot execute UPDATE in a read-only transaction`)
- `SET statement_timeout = '60s'`
- Parameterized: `playlist_name_pattern` (required) + `days_back` (default 60)

### Usage

```bash
./scripts/forensics/run_wooklyn_timeline.sh                 # default
./scripts/forensics/run_wooklyn_timeline.sh '%MIX-2024%' 365
```

`DATABASE_URL` must be in env. See `scripts/forensics/README.md`.

## Test plan

- [x] SQL parses against Postgres 14 (real run, not dry-run)
- [x] All 7 sections render correctly with realistic fixtures simulating a 241→240 silent loss; drift detector returns `-1`
- [x] Empty result behavior with non-matching pattern (0 rows in every section)
- [x] Default `days_back` applies when no `-v days_back` is passed
- [x] `SET default_transaction_read_only = on` rejects `UPDATE`
- [ ] **User to run against production Neon** with `'%WOOKLYN%'` and confirm output reads sensibly
- [ ] **User to act on section 7's `snapshot_id`** if a recent intact snapshot exists and they want to restore WOOKLYN immediately

## Followups

This PR is item 1/5 of the investigation. Remaining:

- **F1+F3** — `verify_playlist_state` URI-multiset verifier + correct rotate expected-URI math
- **F2** — Auto-rollback from snapshot on `PlaylistVerificationError`
- **F4** — Tighten `update_playlist_tracks` / `_batch_add_tracks` return contracts (`SpotifyPartialBatchError`)
- **F5** — Initialize Sentry in app factory + APScheduler scope tags

Each ships as its own PR. See `00_INVESTIGATION.md` for the full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)