### PR TITLE
fix(executors): strict post-write playlist verification (F1+F3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Strict post-write playlist verification** - Replaces rotate executor's 50%-tolerance count check with `JobExecutorService.verify_playlist_state` URI-multiset compare across all executors
+  - Captured a real silent loss on 2026-05-13 (WOOKLYN, Schedule 11: `swap size mismatch — expected 241 tracks, got 240`). The old verifier only warned because drift was <50%; the new verifier raises `PlaylistVerificationError` for any divergence (missing tracks, extra tracks, or substitutions).
+  - Verifies post-write state for: rotate Phase 1 overflow + archive, rotate Phase 2 swap + archive, shuffle, drip (target + raid), raid pull
+  - F3: rotate Phase 2 now computes the correct expected URI set `(prod ∖ swap_out) ∪ swap_in` instead of the original `len(prod_uris)` count, which was wrong whenever `swap_in`/`swap_out` differed (locks, protect_count, depleted eligible pool)
+  - URI-multiset compare honors duplicate counts, so legitimate same-track-listed-twice playlists still pass and silent same-count substitutions fail
+  - Verify call uses `skip_cache=True` on `get_playlist_tracks` so the post-write read can't return a stale cached pre-write state
+  - New exception class `shuffify.services.executors.PlaylistVerificationError(JobExecutionError)` carries `expected`, `actual`, `missing`, `extra`, `playlist_id`, `phase`, `schedule_id` for downstream rollback (F2) and Sentry capture (F5)
+  - New test module `tests/services/test_verify_playlist_state.py` (12 cases); legacy `TestVerifyPlaylistSizeDrift` class removed; `test_job_executor_rotate.py`'s `_make_api` upgraded to a stateful mock that applies writes; pre-existing app-context bug in executor tests fixed via autouse `db_app` fixture
+  - Closes the second deliverable in the WOOKLYN silent-loss investigation
+
 ### Added
 - **Forensic SQL: WOOKLYN loss timeline** - Read-only Postgres script for reconstructing silent track-loss history on any playlist
   - `scripts/forensics/wooklyn_loss_timeline.sql` — seven-section report (matched playlists, schedules, executions, snapshots, activity log, drift detection, restore quick-card)

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/01_verify_wrapper.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/01_verify_wrapper.md
@@ -1,8 +1,15 @@
 # F1 — `verify_playlist_state` URI-set verifier
 
 **Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Status:** COMPLETE — Started 2026-05-16 (combined PR with F3)
 **Targets:** RC1, RC2 (partial — F3 finishes RC2), RC3, RC4, RC5
 **Risk:** Low. Effort: Medium.
+
+## Implementation decisions (2026-05-16, weigh-development-paths)
+
+- **`PlaylistVerificationError` lives in `base_executor.py`**, subclassing `JobExecutionError`. Verification is an executor invariant, not a Spotify-API concept. Existing `except JobExecutionError` handlers catch it for free; F2 will narrow the catch by type before the generic handler.
+- **Cache bypass:** the helper passes `skip_cache=True` to `get_playlist_tracks` (which already supports it — `spotify/api.py:273`). Cheaper than invalidating shared cache state. The original plan options ("invalidate before fetch" vs "add a kwarg") are both made moot by the existing kwarg.
+- **Test layout:** consolidate in `tests/services/test_verify_playlist_state.py` (flat layout matches the rest of the project). The existing `TestVerifyPlaylistSizeDrift` class in `test_job_executor_rotate.py:1961-2017` is removed; those 4 tests were direct unit tests of the helper, not rotate-specific.
 
 ## Context
 

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/03_rotate_expected_math.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/03_rotate_expected_math.md
@@ -1,9 +1,15 @@
 # F3 — Correct the rotate expected-URI computation
 
 **Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
+**Status:** COMPLETE — Started 2026-05-16 (combined PR with F1)
 **Targets:** RC2 (wrong baseline in rotate Phase 2)
 **Depends on:** F1 (uses `verify_playlist_state` for the verify step)
 **Risk:** Low. Effort: Small.
+
+## Implementation decisions (2026-05-16, weigh-development-paths)
+
+- **Ship combined with F1** as one PR — they are interdependent: F1 removes `_verify_playlist_size`, leaving Phase 2 needing F3's correct expected-URI computation.
+- **Archive-side verification is included** here (originally floated as defer-eligible). Symmetric with prod verification; catches archive-side write failures in both Phase 1 (overflow archive) and Phase 2 (swap-out archive). One extra paginated fetch per rotation.
 
 ## Context
 

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/06_neon_forensic_sql.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/06_neon_forensic_sql.md
@@ -1,7 +1,7 @@
 # F6 — Neon forensic SQL for WOOKLYN loss timeline
 
 **Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
-**Status:** IN PROGRESS — Started 2026-05-16
+**Status:** COMPLETE — Merged 2026-05-16 (PR #304, commit `d12141a`)
 **Targets:** "What has WOOKLYN actually lost, and which snapshot do I restore from?"
 **Risk:** None — read-only SQL. Effort: Small.
 

--- a/shuffify/services/executors/__init__.py
+++ b/shuffify/services/executors/__init__.py
@@ -17,9 +17,11 @@ Public API (backward-compatible):
 from shuffify.services.executors.base_executor import (
     JobExecutorService,
     JobExecutionError,
+    PlaylistVerificationError,
 )
 
 __all__ = [
     "JobExecutorService",
     "JobExecutionError",
+    "PlaylistVerificationError",
 ]

--- a/shuffify/services/executors/__init__.py
+++ b/shuffify/services/executors/__init__.py
@@ -18,10 +18,12 @@ from shuffify.services.executors.base_executor import (
     JobExecutorService,
     JobExecutionError,
     PlaylistVerificationError,
+    verify_playlist_state,
 )
 
 __all__ = [
     "JobExecutorService",
     "JobExecutionError",
     "PlaylistVerificationError",
+    "verify_playlist_state",
 ]

--- a/shuffify/services/executors/base_executor.py
+++ b/shuffify/services/executors/base_executor.py
@@ -9,6 +9,7 @@ rotate_executor).
 """
 
 import logging
+from collections import Counter
 from datetime import datetime, timezone
 from typing import List
 
@@ -31,6 +32,42 @@ class JobExecutionError(Exception):
     """Raised when a scheduled job fails to execute."""
 
     pass
+
+
+class PlaylistVerificationError(JobExecutionError):
+    """Raised when post-write playlist state diverges from expected.
+
+    Compares actual URIs to expected URIs as multisets so duplicate
+    track counts must also match. Carries enough detail for F2 to
+    drive an auto-rollback (missing/extra URI lists, schedule_id,
+    phase label).
+    """
+
+    def __init__(
+        self,
+        playlist_id: str,
+        expected: List[str],
+        actual: List[str],
+        schedule_id: int,
+        phase: str,
+    ):
+        self.playlist_id = playlist_id
+        self.expected = expected
+        self.actual = actual
+        self.schedule_id = schedule_id
+        self.phase = phase
+
+        exp_counter = Counter(expected)
+        act_counter = Counter(actual)
+        self.missing = list((exp_counter - act_counter).elements())
+        self.extra = list((act_counter - exp_counter).elements())
+
+        super().__init__(
+            f"Schedule {schedule_id}: {phase} verification failed "
+            f"— expected {len(expected)} tracks, got "
+            f"{len(actual)}, missing {len(self.missing)}, "
+            f"extra {len(self.extra)}"
+        )
 
 
 class JobExecutorService:
@@ -406,3 +443,48 @@ class JobExecutorService:
     ) -> None:
         """Add tracks to a playlist in batches."""
         api.playlist_add_items(playlist_id, uris)
+
+    @staticmethod
+    def verify_playlist_state(
+        api: SpotifyAPI,
+        playlist_id: str,
+        expected_uris: List[str],
+        schedule_id: int,
+        phase: str,
+    ) -> List[str]:
+        """Re-fetch playlist and verify URI multiset matches expected.
+
+        Bypasses the Spotify cache (skip_cache=True) so the read
+        reflects the post-write state, not a pre-write cached copy.
+
+        Args:
+            api: SpotifyAPI client.
+            playlist_id: Target playlist.
+            expected_uris: URIs the playlist should contain (order
+                ignored; duplicate counts honored).
+            schedule_id: For error attribution.
+            phase: Short label like "swap", "shuffle", "drip target".
+
+        Returns:
+            The actual URI list (in fetch order) on success.
+
+        Raises:
+            PlaylistVerificationError: If actual multiset diverges
+                from expected.
+        """
+        verified = api.get_playlist_tracks(
+            playlist_id, skip_cache=True,
+        )
+        actual_uris = [
+            t["uri"] for t in (verified or []) if t.get("uri")
+        ]
+
+        if Counter(actual_uris) != Counter(expected_uris):
+            raise PlaylistVerificationError(
+                playlist_id=playlist_id,
+                expected=expected_uris,
+                actual=actual_uris,
+                schedule_id=schedule_id,
+                phase=phase,
+            )
+        return actual_uris

--- a/shuffify/services/executors/base_executor.py
+++ b/shuffify/services/executors/base_executor.py
@@ -23,6 +23,7 @@ from shuffify.spotify.auth import SpotifyAuthManager, TokenInfo
 from shuffify.spotify.api import SpotifyAPI
 from shuffify.spotify.credentials import SpotifyCredentials
 from shuffify.spotify.exceptions import SpotifyTokenError
+from shuffify.shuffle_algorithms.utils import extract_uris
 from shuffify.enums import JobType, ActivityType
 
 logger = logging.getLogger(__name__)
@@ -38,9 +39,9 @@ class PlaylistVerificationError(JobExecutionError):
     """Raised when post-write playlist state diverges from expected.
 
     Compares actual URIs to expected URIs as multisets so duplicate
-    track counts must also match. Carries enough detail for F2 to
-    drive an auto-rollback (missing/extra URI lists, schedule_id,
-    phase label).
+    track counts must also match. Downstream consumers (rollback,
+    structured logging) read `missing`, `extra`, `playlist_id`,
+    `phase`, and `schedule_id` directly off the instance.
     """
 
     def __init__(
@@ -68,6 +69,50 @@ class PlaylistVerificationError(JobExecutionError):
             f"{len(actual)}, missing {len(self.missing)}, "
             f"extra {len(self.extra)}"
         )
+
+
+def verify_playlist_state(
+    api: SpotifyAPI,
+    playlist_id: str,
+    expected_uris: List[str],
+    schedule_id: int,
+    phase: str,
+) -> List[str]:
+    """Re-fetch playlist and verify URI multiset matches expected.
+
+    Belt-and-suspenders: write methods on SpotifyAPI already invalidate
+    the playlist cache, but skip_cache=True here ensures correctness
+    even if a future write path forgets to invalidate.
+
+    Args:
+        api: SpotifyAPI client.
+        playlist_id: Target playlist.
+        expected_uris: URIs the playlist should contain (order
+            ignored; duplicate counts honored).
+        schedule_id: For error attribution.
+        phase: Short label like "swap", "shuffle", "drip target".
+
+    Returns:
+        The actual URI list (in fetch order) on success.
+
+    Raises:
+        PlaylistVerificationError: If actual multiset diverges
+            from expected.
+    """
+    verified = api.get_playlist_tracks(
+        playlist_id, skip_cache=True,
+    )
+    actual_uris = extract_uris(verified or [])
+
+    if Counter(actual_uris) != Counter(expected_uris):
+        raise PlaylistVerificationError(
+            playlist_id=playlist_id,
+            expected=expected_uris,
+            actual=actual_uris,
+            schedule_id=schedule_id,
+            phase=phase,
+        )
+    return actual_uris
 
 
 class JobExecutorService:
@@ -443,48 +488,3 @@ class JobExecutorService:
     ) -> None:
         """Add tracks to a playlist in batches."""
         api.playlist_add_items(playlist_id, uris)
-
-    @staticmethod
-    def verify_playlist_state(
-        api: SpotifyAPI,
-        playlist_id: str,
-        expected_uris: List[str],
-        schedule_id: int,
-        phase: str,
-    ) -> List[str]:
-        """Re-fetch playlist and verify URI multiset matches expected.
-
-        Bypasses the Spotify cache (skip_cache=True) so the read
-        reflects the post-write state, not a pre-write cached copy.
-
-        Args:
-            api: SpotifyAPI client.
-            playlist_id: Target playlist.
-            expected_uris: URIs the playlist should contain (order
-                ignored; duplicate counts honored).
-            schedule_id: For error attribution.
-            phase: Short label like "swap", "shuffle", "drip target".
-
-        Returns:
-            The actual URI list (in fetch order) on success.
-
-        Raises:
-            PlaylistVerificationError: If actual multiset diverges
-                from expected.
-        """
-        verified = api.get_playlist_tracks(
-            playlist_id, skip_cache=True,
-        )
-        actual_uris = [
-            t["uri"] for t in (verified or []) if t.get("uri")
-        ]
-
-        if Counter(actual_uris) != Counter(expected_uris):
-            raise PlaylistVerificationError(
-                playlist_id=playlist_id,
-                expected=expected_uris,
-                actual=actual_uris,
-                schedule_id=schedule_id,
-                phase=phase,
-            )
-        return actual_uris

--- a/shuffify/services/executors/drip_executor.py
+++ b/shuffify/services/executors/drip_executor.py
@@ -17,6 +17,11 @@ from shuffify.spotify.exceptions import (
     SpotifyNotFoundError,
 )
 from shuffify.enums import SnapshotType, PendingRaidStatus
+from shuffify.shuffle_algorithms.utils import extract_uris
+from shuffify.services.executors.base_executor import (
+    JobExecutionError,
+    verify_playlist_state,
+)
 from shuffify.services.playlist_snapshot_service import (
     PlaylistSnapshotService,
 )
@@ -31,9 +36,6 @@ def execute_drip(
     Move tracks from raid playlist to the top of the
     target playlist.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
     from shuffify.services.raid_link_service import (
         RaidLinkService,
     )
@@ -74,11 +76,7 @@ def execute_drip(
         raid_id = link.raid_playlist_id
 
         raid_tracks = api.get_playlist_tracks(raid_id)
-        raid_uris = [
-            t["uri"]
-            for t in raid_tracks
-            if t.get("uri")
-        ]
+        raid_uris = extract_uris(raid_tracks or [])
 
         if not raid_uris:
             logger.info(
@@ -129,21 +127,15 @@ def execute_drip(
         )
         api.playlist_remove_items(raid_id, drip_uris)
 
-        # F1: verify both sides of the drip. Catches the
-        # add-then-remove failure modes (RC4) where
-        # tracks get marked PROMOTED but don't actually
-        # land on target or aren't removed from raid.
-        from shuffify.services.executors.base_executor import (
-            JobExecutorService,
-        )
-        prev_target_uris = [
-            t.get("uri") for t in target_tracks
-            if t.get("uri")
-        ]
+        # Verify before marking PROMOTED in the DB —
+        # otherwise tracks can be flagged as promoted while
+        # absent from the target (failed add) or still
+        # living in the raid playlist (failed remove).
+        prev_target_uris = extract_uris(target_tracks)
         # drip adds at position=0, so expected order is
         # drip_uris first, then existing target tracks.
         expected_target = list(drip_uris) + prev_target_uris
-        JobExecutorService.verify_playlist_state(
+        verify_playlist_state(
             api, target_id, expected_target,
             schedule.id, "drip target",
         )
@@ -152,7 +144,7 @@ def execute_drip(
         expected_raid = [
             u for u in raid_uris if u not in drip_set
         ]
-        JobExecutorService.verify_playlist_state(
+        verify_playlist_state(
             api, raid_id, expected_raid,
             schedule.id, "drip raid",
         )
@@ -163,11 +155,7 @@ def execute_drip(
 
         # Reconcile lock positions (drip at pos 0
         # shifts all existing tracks down)
-        new_total_uris = drip_uris + [
-            t.get("uri")
-            for t in target_tracks
-            if t.get("uri")
-        ]
+        new_total_uris = drip_uris + prev_target_uris
         from shuffify.services.track_lock_service import (
             TrackLockService,
         )
@@ -226,11 +214,7 @@ def _auto_snapshot_before_drip(
 
         # Snapshot target
         target_tracks = api.get_playlist_tracks(target_id)
-        target_uris = [
-            t.get("uri")
-            for t in target_tracks
-            if t.get("uri")
-        ]
+        target_uris = extract_uris(target_tracks or [])
         if target_uris:
             PlaylistSnapshotService.create_snapshot(
                 user_id=schedule.user_id,
@@ -251,11 +235,7 @@ def _auto_snapshot_before_drip(
 
         # Snapshot raid playlist
         raid_tracks = api.get_playlist_tracks(raid_id)
-        raid_uris = [
-            t.get("uri")
-            for t in raid_tracks
-            if t.get("uri")
-        ]
+        raid_uris = extract_uris(raid_tracks or [])
         if raid_uris:
             PlaylistSnapshotService.create_snapshot(
                 user_id=schedule.user_id,

--- a/shuffify/services/executors/drip_executor.py
+++ b/shuffify/services/executors/drip_executor.py
@@ -128,6 +128,35 @@ def execute_drip(
             target_id, drip_uris, position=0
         )
         api.playlist_remove_items(raid_id, drip_uris)
+
+        # F1: verify both sides of the drip. Catches the
+        # add-then-remove failure modes (RC4) where
+        # tracks get marked PROMOTED but don't actually
+        # land on target or aren't removed from raid.
+        from shuffify.services.executors.base_executor import (
+            JobExecutorService,
+        )
+        prev_target_uris = [
+            t.get("uri") for t in target_tracks
+            if t.get("uri")
+        ]
+        # drip adds at position=0, so expected order is
+        # drip_uris first, then existing target tracks.
+        expected_target = list(drip_uris) + prev_target_uris
+        JobExecutorService.verify_playlist_state(
+            api, target_id, expected_target,
+            schedule.id, "drip target",
+        )
+
+        drip_set = set(drip_uris)
+        expected_raid = [
+            u for u in raid_uris if u not in drip_set
+        ]
+        JobExecutorService.verify_playlist_state(
+            api, raid_id, expected_raid,
+            schedule.id, "drip raid",
+        )
+
         _mark_dripped_as_promoted(
             user_id, target_id, drip_uris
         )

--- a/shuffify/services/executors/raid_executor.py
+++ b/shuffify/services/executors/raid_executor.py
@@ -104,7 +104,8 @@ def execute_raid(
         track_dicts = _build_track_dicts(api, new_uris)
 
         _add_to_raid_playlist(
-            api, schedule.user_id, target_id, new_uris
+            api, schedule.user_id, target_id, new_uris,
+            schedule_id=schedule.id,
         )
 
         staged = PendingRaidService.stage_tracks(
@@ -181,12 +182,22 @@ def _auto_snapshot_before_raid(
 
 
 def _add_to_raid_playlist(
-    api, user_id, target_id, uris,
+    api, user_id, target_id, uris, schedule_id=None,
 ):
     """Add raided tracks to the raid Spotify playlist
-    if a RaidPlaylistLink exists."""
+    if a RaidPlaylistLink exists, and verify the resulting
+    state (F1).
+
+    The previous implementation swallowed errors as a
+    warning and reported staged-DB counts as Spotify
+    reality. Now any HTTP failure or post-write divergence
+    propagates so the orchestrator can fail/rollback.
+    """
     from shuffify.services.raid_link_service import (
         RaidLinkService,
+    )
+    from shuffify.services.executors.base_executor import (
+        JobExecutorService,
     )
 
     link = RaidLinkService.get_link_for_playlist(
@@ -195,19 +206,30 @@ def _add_to_raid_playlist(
     if not link:
         return
 
-    try:
-        api.playlist_add_items(
-            link.raid_playlist_id, uris
-        )
-        logger.info(
-            "Added %d tracks to raid playlist %s",
-            len(uris), link.raid_playlist_id,
-        )
-    except Exception as e:
-        logger.warning(
-            "Failed to add tracks to raid "
-            "playlist: %s", e
-        )
+    # Capture pre-write raid contents for the post-write
+    # verification expected set.
+    prev_raid_tracks = api.get_playlist_tracks(
+        link.raid_playlist_id
+    )
+    prev_raid_uris = [
+        t.get("uri") for t in (prev_raid_tracks or [])
+        if t.get("uri")
+    ]
+
+    api.playlist_add_items(
+        link.raid_playlist_id, uris
+    )
+    logger.info(
+        "Added %d tracks to raid playlist %s",
+        len(uris), link.raid_playlist_id,
+    )
+
+    expected_raid = prev_raid_uris + list(uris)
+    JobExecutorService.verify_playlist_state(
+        api, link.raid_playlist_id, expected_raid,
+        schedule_id if schedule_id is not None else 0,
+        "raid pull",
+    )
 
 
 def _fetch_raid_sources_with_limits(

--- a/shuffify/services/executors/raid_executor.py
+++ b/shuffify/services/executors/raid_executor.py
@@ -19,6 +19,11 @@ from shuffify.spotify.exceptions import (
     SpotifyNotFoundError,
 )
 from shuffify.enums import SnapshotType
+from shuffify.shuffle_algorithms.utils import extract_uris
+from shuffify.services.executors.base_executor import (
+    JobExecutionError,
+    verify_playlist_state,
+)
 from shuffify.services.playlist_snapshot_service import (
     PlaylistSnapshotService,
 )
@@ -40,10 +45,6 @@ def execute_raid(
     Pull new tracks from source playlists, add to the raid
     playlist (if linked), and stage in PendingRaidTrack.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
-
     target_id = schedule.target_playlist_id
     source_ids = schedule.source_playlist_ids or []
 
@@ -105,7 +106,7 @@ def execute_raid(
 
         _add_to_raid_playlist(
             api, schedule.user_id, target_id, new_uris,
-            schedule_id=schedule.id,
+            schedule.id,
         )
 
         staged = PendingRaidService.stage_tracks(
@@ -153,11 +154,7 @@ def _auto_snapshot_before_raid(
             return
 
         target_tracks = api.get_playlist_tracks(target_id)
-        pre_raid_uris = [
-            t.get("uri")
-            for t in target_tracks
-            if t.get("uri")
-        ]
+        pre_raid_uris = extract_uris(target_tracks or [])
         if pre_raid_uris:
             PlaylistSnapshotService.create_snapshot(
                 user_id=schedule.user_id,
@@ -182,22 +179,15 @@ def _auto_snapshot_before_raid(
 
 
 def _add_to_raid_playlist(
-    api, user_id, target_id, uris, schedule_id=None,
+    api, user_id, target_id, uris, schedule_id,
 ):
     """Add raided tracks to the raid Spotify playlist
     if a RaidPlaylistLink exists, and verify the resulting
-    state (F1).
-
-    The previous implementation swallowed errors as a
-    warning and reported staged-DB counts as Spotify
-    reality. Now any HTTP failure or post-write divergence
+    state. Any HTTP failure or post-write divergence
     propagates so the orchestrator can fail/rollback.
     """
     from shuffify.services.raid_link_service import (
         RaidLinkService,
-    )
-    from shuffify.services.executors.base_executor import (
-        JobExecutorService,
     )
 
     link = RaidLinkService.get_link_for_playlist(
@@ -206,15 +196,13 @@ def _add_to_raid_playlist(
     if not link:
         return
 
-    # Capture pre-write raid contents for the post-write
-    # verification expected set.
+    # The raid playlist is distinct from `target_id`, so its
+    # contents aren't fetched anywhere upstream. Read here
+    # to build the post-write expected URI set.
     prev_raid_tracks = api.get_playlist_tracks(
         link.raid_playlist_id
     )
-    prev_raid_uris = [
-        t.get("uri") for t in (prev_raid_tracks or [])
-        if t.get("uri")
-    ]
+    prev_raid_uris = extract_uris(prev_raid_tracks or [])
 
     api.playlist_add_items(
         link.raid_playlist_id, uris
@@ -225,10 +213,9 @@ def _add_to_raid_playlist(
     )
 
     expected_raid = prev_raid_uris + list(uris)
-    JobExecutorService.verify_playlist_state(
+    verify_playlist_state(
         api, link.raid_playlist_id, expected_raid,
-        schedule_id if schedule_id is not None else 0,
-        "raid pull",
+        schedule_id, "raid pull",
     )
 
 

--- a/shuffify/services/executors/rotate_executor.py
+++ b/shuffify/services/executors/rotate_executor.py
@@ -211,48 +211,6 @@ def _sample_at_most(pool, count):
     return random.sample(pool, count)
 
 
-def _verify_playlist_size(
-    api, target_id, expected, schedule_id, phase,
-):
-    """Re-fetch playlist to get actual track count.
-
-    Logs a warning if the actual size differs from
-    expected, indicating a silent API failure. Raises
-    JobExecutionError if drift exceeds 50% of expected
-    size, indicating a serious Spotify failure.
-
-    Returns:
-        Actual track count.
-    """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
-
-    verified = api.get_playlist_tracks(target_id)
-    actual = sum(
-        1 for t in verified if t.get("uri")
-    ) if verified else 0
-
-    if actual != expected:
-        drift = abs(actual - expected)
-        threshold = max(1, expected // 2)
-        if drift > threshold:
-            raise JobExecutionError(
-                "Schedule {}: {} size drift too "
-                "large — expected {} tracks, got "
-                "{}".format(
-                    schedule_id, phase,
-                    expected, actual,
-                )
-            )
-        logger.warning(
-            "Schedule %s: %s size mismatch — "
-            "expected %d tracks, got %d",
-            schedule_id, phase, expected, actual,
-        )
-    return actual
-
-
 def _purge_archive_overlaps(
     api, archive_id, archive_uris, prod_set,
 ):
@@ -441,10 +399,28 @@ def _rotate_swap(
                 api, archive_id, new_to_archive
             )
 
-        expected = len(prod_uris) - len(overflow_uris)
-        actual_total = _verify_playlist_size(
-            api, target_id, expected,
-            schedule.id, "overflow removal",
+        # Verify production: original ∖ overflow.
+        overflow_set = set(overflow_uris)
+        expected_prod = [
+            u for u in prod_uris
+            if u not in overflow_set
+        ]
+        verified_prod = (
+            JobExecutorService.verify_playlist_state(
+                api, target_id, expected_prod,
+                schedule.id, "overflow",
+            )
+        )
+        actual_total = len(verified_prod)
+
+        # Verify archive: previous (post-purge) ∪
+        # new_to_archive.
+        expected_archive = (
+            list(archive_uris) + new_to_archive
+        )
+        JobExecutorService.verify_playlist_state(
+            api, archive_id, expected_archive,
+            schedule.id, "overflow archive",
         )
 
         logger.info(
@@ -469,6 +445,11 @@ def _rotate_swap(
     # Randomly select swap-out tracks from eligible
     swap_out_uris = _sample_at_most(
         eligible_uris, len(swap_in_uris)
+    )
+
+    swapped = min(
+        len(swap_in_uris),
+        len(swap_out_uris),
     )
 
     if swap_in_uris and swap_out_uris:
@@ -499,15 +480,41 @@ def _rotate_swap(
             api, target_id, swap_in_uris
         )
 
-    swapped = min(
-        len(swap_in_uris),
-        len(swap_out_uris),
-    )
+        # F3: expected production =
+        # (prod ∖ swap_out) ∪ swap_in. The original size
+        # is wrong when swap_in/swap_out differ (e.g.
+        # eligible pool depleted by locks/protect).
+        swap_out_set = set(swap_out_uris)
+        expected_prod = [
+            u for u in prod_uris
+            if u not in swap_out_set
+        ]
+        expected_prod.extend(swap_in_uris)
+        verified_prod = (
+            JobExecutorService.verify_playlist_state(
+                api, target_id, expected_prod,
+                schedule.id, "swap",
+            )
+        )
+        actual_total = len(verified_prod)
 
-    actual_total = _verify_playlist_size(
-        api, target_id, len(prod_uris),
-        schedule.id, "swap",
-    )
+        # F3: expected archive =
+        # (archive ∖ swap_in) ∪ new_to_archive.
+        swap_in_set = set(swap_in_uris)
+        expected_archive = [
+            u for u in archive_uris
+            if u not in swap_in_set
+        ]
+        expected_archive.extend(new_to_archive)
+        JobExecutorService.verify_playlist_state(
+            api, archive_id, expected_archive,
+            schedule.id, "swap archive",
+        )
+    else:
+        # Nothing to swap (archive empty or eligible pool
+        # depleted). No writes happened, so the prod size
+        # is unchanged.
+        actual_total = len(prod_uris)
 
     logger.info(
         "Schedule %s: swapped %d tracks between "

--- a/shuffify/services/executors/rotate_executor.py
+++ b/shuffify/services/executors/rotate_executor.py
@@ -16,11 +16,32 @@ from shuffify.spotify.exceptions import (
     SpotifyNotFoundError,
 )
 from shuffify.enums import SnapshotType, RotationMode
+from shuffify.shuffle_algorithms.utils import extract_uris
+from shuffify.services.executors.base_executor import (
+    JobExecutionError,
+    JobExecutorService,
+    verify_playlist_state,
+)
 from shuffify.services.playlist_snapshot_service import (
     PlaylistSnapshotService,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _expected_after(prev_uris, removed_uris, added_uris):
+    """Compute the URI list a playlist should contain after
+    `removed_uris` are removed and `added_uris` are appended.
+
+    Used by every verify call site so the expected-set
+    formula lives in one place. Removal is a set-difference
+    (Spotify removes every occurrence of a given URI), then
+    additions are appended in order.
+    """
+    removed_set = set(removed_uris)
+    return [u for u in prev_uris if u not in removed_set] + list(
+        added_uris
+    )
 
 
 def execute_rotate(
@@ -30,10 +51,6 @@ def execute_rotate(
     Rotate tracks between production and archive
     playlists.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
-
     target_id = schedule.target_playlist_id
     (
         rotation_mode, rotation_count,
@@ -104,9 +121,6 @@ def _validate_rotation_config(
         JobExecutionError: If mode is invalid or no
             pair found.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
     from shuffify.services.playlist_pair_service import (
         PlaylistPairService,
     )
@@ -229,10 +243,6 @@ def _purge_archive_overlaps(
             since proceeding with stale overlaps would
             contaminate the swap-in pool.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
-
     overlaps, cleaned = [], []
     for u in archive_uris:
         (overlaps if u in prod_set
@@ -273,10 +283,6 @@ def _checked_remove(
     Raises JobExecutionError if the Spotify API returns
     a falsy result, indicating a silent failure.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
-
     result = api.playlist_remove_items(
         playlist_id, uris
     )
@@ -313,18 +319,10 @@ def _rotate_swap(
     swap rotation_count tracks between production and
     archive.
     """
-    from shuffify.services.executors.base_executor import (
-        JobExecutorService,
-    )
-
     archive_tracks = api.get_playlist_tracks(
         archive_id
     )
-    archive_uris = [
-        t["uri"]
-        for t in archive_tracks
-        if t.get("uri")
-    ]
+    archive_uris = extract_uris(archive_tracks or [])
 
     prod_set = set(prod_uris)
 
@@ -399,26 +397,19 @@ def _rotate_swap(
                 api, archive_id, new_to_archive
             )
 
-        # Verify production: original ∖ overflow.
-        overflow_set = set(overflow_uris)
-        expected_prod = [
-            u for u in prod_uris
-            if u not in overflow_set
-        ]
-        verified_prod = (
-            JobExecutorService.verify_playlist_state(
-                api, target_id, expected_prod,
-                schedule.id, "overflow",
-            )
+        expected_prod = _expected_after(
+            prod_uris, overflow_uris, [],
+        )
+        verified_prod = verify_playlist_state(
+            api, target_id, expected_prod,
+            schedule.id, "overflow",
         )
         actual_total = len(verified_prod)
 
-        # Verify archive: previous (post-purge) ∪
-        # new_to_archive.
-        expected_archive = (
-            list(archive_uris) + new_to_archive
+        expected_archive = _expected_after(
+            archive_uris, [], new_to_archive,
         )
-        JobExecutorService.verify_playlist_state(
+        verify_playlist_state(
             api, archive_id, expected_archive,
             schedule.id, "overflow archive",
         )
@@ -480,33 +471,22 @@ def _rotate_swap(
             api, target_id, swap_in_uris
         )
 
-        # F3: expected production =
-        # (prod ∖ swap_out) ∪ swap_in. The original size
-        # is wrong when swap_in/swap_out differ (e.g.
-        # eligible pool depleted by locks/protect).
-        swap_out_set = set(swap_out_uris)
-        expected_prod = [
-            u for u in prod_uris
-            if u not in swap_out_set
-        ]
-        expected_prod.extend(swap_in_uris)
-        verified_prod = (
-            JobExecutorService.verify_playlist_state(
-                api, target_id, expected_prod,
-                schedule.id, "swap",
-            )
+        # Asymmetric swap (locks/protect/depleted pool can
+        # make swap_in and swap_out differ in length) means
+        # we can't verify against the original prod size.
+        expected_prod = _expected_after(
+            prod_uris, swap_out_uris, swap_in_uris,
+        )
+        verified_prod = verify_playlist_state(
+            api, target_id, expected_prod,
+            schedule.id, "swap",
         )
         actual_total = len(verified_prod)
 
-        # F3: expected archive =
-        # (archive ∖ swap_in) ∪ new_to_archive.
-        swap_in_set = set(swap_in_uris)
-        expected_archive = [
-            u for u in archive_uris
-            if u not in swap_in_set
-        ]
-        expected_archive.extend(new_to_archive)
-        JobExecutorService.verify_playlist_state(
+        expected_archive = _expected_after(
+            archive_uris, swap_in_uris, new_to_archive,
+        )
+        verify_playlist_state(
             api, archive_id, expected_archive,
             schedule.id, "swap archive",
         )

--- a/shuffify/services/executors/shuffle_executor.py
+++ b/shuffify/services/executors/shuffle_executor.py
@@ -158,6 +158,18 @@ def execute_shuffle(
             target_id, shuffled_uris
         )
 
+        # F1: verify post-write state. Catches silent
+        # multi-batch truncation in update_playlist_tracks
+        # (RC3) — the function returns True even if
+        # batches 2+ silently dropped.
+        from shuffify.services.executors.base_executor import (
+            JobExecutorService,
+        )
+        JobExecutorService.verify_playlist_state(
+            api, target_id, shuffled_uris,
+            schedule.id, "shuffle",
+        )
+
         # Reconcile lock positions after reorder
         TrackLockService.safe_reconcile_positions(
             schedule.user_id, target_id,

--- a/shuffify/services/executors/shuffle_executor.py
+++ b/shuffify/services/executors/shuffle_executor.py
@@ -12,6 +12,11 @@ from shuffify.spotify.exceptions import (
 )
 from shuffify.enums import SnapshotType
 from shuffify.shuffle_algorithms.registry import ShuffleRegistry
+from shuffify.shuffle_algorithms.utils import extract_uris
+from shuffify.services.executors.base_executor import (
+    JobExecutionError,
+    verify_playlist_state,
+)
 from shuffify.services.playlist_snapshot_service import (
     PlaylistSnapshotService,
 )
@@ -23,10 +28,6 @@ def execute_shuffle(
     schedule: Schedule, api: SpotifyAPI
 ) -> dict:
     """Run a shuffle algorithm on the target playlist."""
-    from shuffify.services.executors.base_executor import (
-        JobExecutionError,
-    )
-
     target_id = schedule.target_playlist_id
     algorithm_name = schedule.algorithm_name
 
@@ -158,14 +159,10 @@ def execute_shuffle(
             target_id, shuffled_uris
         )
 
-        # F1: verify post-write state. Catches silent
-        # multi-batch truncation in update_playlist_tracks
-        # (RC3) — the function returns True even if
-        # batches 2+ silently dropped.
-        from shuffify.services.executors.base_executor import (
-            JobExecutorService,
-        )
-        JobExecutorService.verify_playlist_state(
+        # Catches silent multi-batch truncation:
+        # update_playlist_tracks returns True even if a
+        # POST batch after the initial PUT fails.
+        verify_playlist_state(
             api, target_id, shuffled_uris,
             schedule.id, "shuffle",
         )
@@ -212,11 +209,7 @@ def _auto_snapshot_before_shuffle(
     """Create an auto-snapshot before a scheduled shuffle
     if enabled."""
     try:
-        pre_shuffle_uris = [
-            t["uri"]
-            for t in raw_tracks
-            if t.get("uri")
-        ]
+        pre_shuffle_uris = extract_uris(raw_tracks)
         if (
             pre_shuffle_uris
             and PlaylistSnapshotService

--- a/tests/services/test_drip_executor.py
+++ b/tests/services/test_drip_executor.py
@@ -137,27 +137,47 @@ class TestExecuteDrip:
         user, raid_link, schedule, mock_api,
     ):
         """Drip moves tracks from raid to target."""
-        raid_tracks = [
-            {"uri": f"spotify:track:{i}"}
-            for i in range(5)
-        ]
-        target_tracks = [
-            {"uri": "spotify:track:existing"}
-        ]
+        # Stateful mock so F1's post-write verify reads
+        # back what add/remove actually wrote.
+        state = {
+            "raid_drip": [
+                f"spotify:track:{i}" for i in range(5)
+            ],
+            "target_drip": ["spotify:track:existing"],
+        }
 
-        call_count = [0]
+        def get_tracks_side_effect(pid, skip_cache=False):
+            return [
+                {"uri": u} for u in state.get(pid, [])
+            ]
 
-        def get_tracks_side_effect(pid):
-            if pid == "raid_drip":
-                return raid_tracks
-            return target_tracks
+        def add_side_effect(pid, uris, position=None):
+            if position is None:
+                state.setdefault(pid, []).extend(uris)
+            else:
+                cur = state.setdefault(pid, [])
+                state[pid] = (
+                    cur[:position]
+                    + list(uris)
+                    + cur[position:]
+                )
+
+        def remove_side_effect(pid, uris):
+            drop = set(uris)
+            state[pid] = [
+                u for u in state.get(pid, [])
+                if u not in drop
+            ]
+            return True
 
         mock_api.get_playlist_tracks.side_effect = (
             get_tracks_side_effect
         )
-        mock_api.playlist_add_items.return_value = None
-        mock_api.playlist_remove_items.return_value = (
-            True
+        mock_api.playlist_add_items.side_effect = (
+            add_side_effect
+        )
+        mock_api.playlist_remove_items.side_effect = (
+            remove_side_effect
         )
 
         result = execute_drip(schedule, mock_api)

--- a/tests/services/test_job_executor_rotate.py
+++ b/tests/services/test_job_executor_rotate.py
@@ -11,18 +11,27 @@ from unittest.mock import patch, MagicMock
 from shuffify.services.executors import (
     JobExecutorService,
     JobExecutionError,
+    PlaylistVerificationError,
 )
 from shuffify.services.executors.rotate_executor import (
     execute_rotate,
     _purge_archive_overlaps,
     _checked_remove,
-    _verify_playlist_size,
 )
 from shuffify.spotify.exceptions import (
     SpotifyAPIError,
     SpotifyNotFoundError,
 )
 from shuffify.enums import JobType
+
+
+# Rotate-executor tests need a Flask app context because the
+# executor calls TrackLockService.safe_get_locked_uris, which
+# touches db.session even in its except-branch fallback.
+@pytest.fixture(autouse=True)
+def _app_ctx(db_app):
+    with db_app.app_context():
+        yield
 
 
 def _make_schedule(
@@ -56,47 +65,84 @@ def _make_api(
     prod_tracks=None, archive_tracks=None,
     post_removal_prod=None,
 ):
-    """Create a mock SpotifyAPI.
+    """Create a stateful mock SpotifyAPI.
+
+    `playlist_add_items` and `playlist_remove_items` mutate
+    internal state so a follow-up `get_playlist_tracks`
+    reflects the writes — which is what F1's
+    `verify_playlist_state` reads back to confirm the
+    post-write state.
 
     Args:
         prod_tracks: Initial production playlist tracks.
         archive_tracks: Initial archive playlist tracks.
-        post_removal_prod: Tracks returned for the
-            verification re-fetch of the production
-            playlist. If None, returns prod_tracks.
+        post_removal_prod: Optional override that forces
+            the second-and-later get_playlist_tracks(target1)
+            return value, regardless of what writes happened.
+            Use this only to simulate a Spotify silent
+            failure for PlaylistVerificationError tests.
     """
     api = MagicMock()
 
-    # Track how many times target1 is fetched.
-    # First call returns initial tracks, subsequent
-    # calls return post_removal_prod (for verification).
-    target_fetch_count = {"n": 0}
-    final_prod = (
-        post_removal_prod
-        if post_removal_prod is not None
-        else prod_tracks
-    )
+    state = {
+        "target1": [
+            t["uri"] for t in (prod_tracks or [])
+            if t.get("uri")
+        ],
+        "archive1": [
+            t["uri"] for t in (archive_tracks or [])
+            if t.get("uri")
+        ],
+    }
 
-    def get_tracks(playlist_id):
+    target_fetch_count = {"n": 0}
+    forced_post = post_removal_prod  # may be None
+
+    def get_tracks(playlist_id, skip_cache=False):
         if playlist_id == "target1":
             target_fetch_count["n"] += 1
-            if target_fetch_count["n"] == 1:
-                return prod_tracks or []
-            # Subsequent calls return post-removal state
-            return final_prod or []
-        if playlist_id == "archive1":
-            return archive_tracks or []
-        return []
+            if (
+                forced_post is not None
+                and target_fetch_count["n"] >= 2
+            ):
+                return list(forced_post)
+        return [
+            {"uri": u, "name": u}
+            for u in state.get(playlist_id, [])
+        ]
+
+    def add_items(
+        playlist_id, uris, position=None,
+    ):
+        if playlist_id not in state:
+            state[playlist_id] = []
+        if position is None:
+            state[playlist_id].extend(uris)
+        else:
+            state[playlist_id] = (
+                state[playlist_id][:position]
+                + list(uris)
+                + state[playlist_id][position:]
+            )
+
+    def remove_items(playlist_id, uris):
+        to_remove = set(uris)
+        state[playlist_id] = [
+            u for u in state.get(playlist_id, [])
+            if u not in to_remove
+        ]
+        return True
 
     api.get_playlist_tracks = MagicMock(
         side_effect=get_tracks
     )
     api.playlist_remove_items = MagicMock(
-        return_value=True
+        side_effect=remove_items
     )
     api.playlist_add_items = MagicMock(
-        return_value=None
+        side_effect=add_items
     )
+    api._state = state
     return api
 
 
@@ -137,14 +183,9 @@ class TestExecuteRotateSwap:
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2", "a3"])
-        # After swap: 2 removed, 2 added = still 3
-        post_prod = _make_tracks(
-            ["p3", "a2", "a3"]
-        )
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
-            post_removal_prod=post_prod,
         )
         schedule = _make_schedule(
             rotation_count=2,
@@ -785,11 +826,15 @@ class TestVerification:
         "shuffify.services.executors.rotate_executor"
         ".random"
     )
-    def test_overflow_returns_verified_total(
+    def test_overflow_raises_when_post_state_drifts(
         self, mock_random, mock_pair, mock_snap
     ):
-        """Phase 1 returns actual count from re-fetch,
-        not calculated."""
+        """F1: Phase 1 raises PlaylistVerificationError when
+        the post-write playlist size diverges from
+        expected. (Replaces the pre-F1 loose-verify test
+        which asserted the old behavior of returning the
+        drifted count.)
+        """
         mock_pair.return_value = _make_pair()
         mock_snap.is_auto_snapshot_enabled.return_value = (
             False
@@ -797,8 +842,8 @@ class TestVerification:
 
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
-        # Simulate removal partially failing:
-        # expected 5 but got 7
+        # Simulate Spotify partially failing the removal:
+        # expected 5 but got 7 (silent loss class).
         post_prod = _make_tracks(uris[:7])
         api = _make_api(
             prod_tracks=prod,
@@ -812,10 +857,8 @@ class TestVerification:
             lambda lst, n: lst[:n]
         )
 
-        result = execute_rotate(schedule, api)
-
-        # Should return actual 7, not calculated 5
-        assert result["tracks_total"] == 7
+        with pytest.raises(PlaylistVerificationError):
+            execute_rotate(schedule, api)
 
     @patch(
         "shuffify.services.executors.rotate_executor"
@@ -829,10 +872,14 @@ class TestVerification:
         "shuffify.services.executors.rotate_executor"
         ".random"
     )
-    def test_swap_returns_verified_total(
+    def test_swap_raises_on_unexpected_extra_track(
         self, mock_random, mock_pair, mock_snap
     ):
-        """Phase 2 returns actual count from re-fetch."""
+        """F1: Phase 2 raises PlaylistVerificationError
+        when the post-write playlist contains an extra
+        track that the executor did not add. (Replaces the
+        pre-F1 loose-verify test which accepted the drift.)
+        """
         mock_pair.return_value = _make_pair()
         mock_snap.is_auto_snapshot_enabled.return_value = (
             False
@@ -840,8 +887,6 @@ class TestVerification:
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2"])
-        # Simulate: after swap, playlist gained a track
-        # (unexpected)
         post_prod = _make_tracks(
             ["p3", "a1", "a2", "extra"]
         )
@@ -858,10 +903,8 @@ class TestVerification:
             lambda lst, n: lst[:n]
         )
 
-        result = execute_rotate(schedule, api)
-
-        # Should reflect the actual re-fetched count
-        assert result["tracks_total"] == 4
+        with pytest.raises(PlaylistVerificationError):
+            execute_rotate(schedule, api)
 
 
 # =============================================================================
@@ -967,14 +1010,9 @@ class TestExecuteRotateValidation:
         archive = _make_tracks(
             ["a{}".format(i) for i in range(10)]
         )
-        post_prod = _make_tracks(
-            uris[5:]
-            + ["a{}".format(i) for i in range(5, 10)]
-        )
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
-            post_removal_prod=post_prod,
         )
         schedule = _make_schedule()
         schedule.algorithm_params = {
@@ -1084,7 +1122,6 @@ class TestExecuteRotateValidation:
         assert result["tracks_total"] == 2
 
 
-
 # =============================================================================
 # PROTECT COUNT INTEGRATION
 # =============================================================================
@@ -1120,13 +1157,9 @@ class TestProtectCount:
         archive = _make_tracks(
             ["a1", "a2", "a3"]
         )
-        post_prod = _make_tracks(
-            ["p1", "p2", "p5", "a2", "a3"]
-        )
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
-            post_removal_prod=post_prod,
         )
         schedule = _make_schedule(
             rotation_count=2,
@@ -1262,13 +1295,9 @@ class TestTargetSize:
         archive = _make_tracks(
             ["a{}".format(i) for i in range(5)]
         )
-        post_prod = _make_tracks(
-            uris[3:] + ["a2", "a3", "a4"]
-        )
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
-            post_removal_prod=post_prod,
         )
         schedule = _make_schedule(
             rotation_count=3,
@@ -1445,13 +1474,9 @@ class TestOperationOrdering:
             ["p1", "p2", "p3", "p4"]
         )
         archive = _make_tracks(["a1", "a2"])
-        post_prod = _make_tracks(
-            ["p3", "p4", "a1", "a2"]
-        )
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
-            post_removal_prod=post_prod,
         )
         mock_random.sample.side_effect = (
             lambda lst, n: lst[:n]
@@ -1479,9 +1504,16 @@ class TestOperationOrdering:
             target_size=4,
         )
 
+        # This test asserts call ordering only — patch out
+        # verify_playlist_state since the test's mocks
+        # short-circuit the state mutation that verify
+        # would otherwise see.
         with patch.object(
             JobExecutorService, "_batch_add_tracks",
             side_effect=track_add,
+        ), patch.object(
+            JobExecutorService, "verify_playlist_state",
+            return_value=[],
         ):
             execute_rotate(schedule, api)
 
@@ -1574,8 +1606,13 @@ class TestCheckedRemove:
             archive_tracks=archive,
         )
         # No overlaps so no purge call;
-        # first remove (swap prod-remove) fails
-        api.playlist_remove_items.return_value = False
+        # first remove (swap prod-remove) returns falsy
+        # so _checked_remove raises. side_effect takes
+        # precedence over return_value with the stateful
+        # mock — override to return False.
+        api.playlist_remove_items.side_effect = (
+            lambda *a, **k: False
+        )
         schedule = _make_schedule(
             rotation_count=2,
             target_size=3,
@@ -1615,9 +1652,11 @@ class TestCheckedRemove:
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
         api = _make_api(prod_tracks=prod)
-        # Purge has no overlaps so no call;
-        # overflow remove returns False
-        api.playlist_remove_items.return_value = False
+        # Purge has no overlaps so no call; overflow remove
+        # returns falsy so _checked_remove raises.
+        api.playlist_remove_items.side_effect = (
+            lambda *a, **k: False
+        )
         schedule = _make_schedule(
             rotation_count=2,
             target_size=5,
@@ -1953,65 +1992,64 @@ class TestPurgeArchiveErrorHandling:
             execute_rotate(schedule, api)
 
 
+# Verifier-helper unit tests live in
+# tests/services/test_verify_playlist_state.py. This file
+# only exercises the rotate integration of F1 strict
+# verification below.
+
+
 # =============================================================================
-# VERIFY PLAYLIST SIZE DRIFT (Fix #5 bonus)
+# F1 STRICT VERIFICATION INTEGRATION
 # =============================================================================
 
 
-class TestVerifyPlaylistSizeDrift:
-    """Tests for _verify_playlist_size drift detection."""
+class TestRotateStrictVerification:
+    """End-to-end rotate tests that exercise the F1
+    PlaylistVerificationError path by forcing the API mock
+    to return a post-write state that diverges from what
+    the executor wrote.
+    """
 
-    def test_small_drift_returns_actual(self):
-        """Small drift logs warning but returns actual."""
-        api = MagicMock()
-        api.get_playlist_tracks.return_value = (
-            _make_tracks(["u1", "u2", "u3"])
+    @patch(
+        "shuffify.services.executors.rotate_executor"
+        ".PlaylistSnapshotService"
+    )
+    @patch(
+        "shuffify.services.playlist_pair_service"
+        ".PlaylistPairService.get_pair_for_playlist"
+    )
+    @patch(
+        "shuffify.services.executors.rotate_executor"
+        ".random"
+    )
+    def test_swap_raises_when_post_state_drifts(
+        self, mock_random, mock_pair, mock_snap,
+    ):
+        """If Spotify silently drops a track during the
+        swap, the post-write fetch diverges from the
+        executor's expected set and verification raises.
+        """
+        mock_pair.return_value = _make_pair()
+        mock_snap.is_auto_snapshot_enabled.return_value = (
+            False
+        )
+        mock_random.sample.side_effect = (
+            lambda lst, n: lst[:n]
         )
 
-        result = _verify_playlist_size(
-            api, "playlist1", 4, 42, "test",
+        prod = _make_tracks(["p1", "p2", "p3"])
+        archive = _make_tracks(["a1", "a2"])
+        # Force the verify re-fetch to claim one track went
+        # missing — simulates the WOOKLYN-class silent loss.
+        post_prod = _make_tracks(["p3", "a1"])
+        api = _make_api(
+            prod_tracks=prod,
+            archive_tracks=archive,
+            post_removal_prod=post_prod,
         )
-        assert result == 3
-
-    def test_large_drift_raises(self):
-        """Drift > 50% of expected raises error."""
-        api = MagicMock()
-        # Expected 10 tracks, got 2 (drift=8 > 5)
-        api.get_playlist_tracks.return_value = (
-            _make_tracks(["u1", "u2"])
-        )
-
-        with pytest.raises(
-            JobExecutionError,
-            match="size drift too large",
-        ):
-            _verify_playlist_size(
-                api, "playlist1", 10, 42, "test",
-            )
-
-    def test_exact_match_no_error(self):
-        """Exact match raises nothing."""
-        api = MagicMock()
-        api.get_playlist_tracks.return_value = (
-            _make_tracks(["u1", "u2", "u3"])
+        schedule = _make_schedule(
+            rotation_count=2, target_size=3,
         )
 
-        result = _verify_playlist_size(
-            api, "playlist1", 3, 42, "test",
-        )
-        assert result == 3
-
-    def test_zero_expected_one_actual_raises(self):
-        """Drift from 0 expected to 1 actual raises
-        (threshold=max(1,0)=1, drift=1 > 1 is false,
-        so it warns instead)."""
-        api = MagicMock()
-        api.get_playlist_tracks.return_value = (
-            _make_tracks(["u1"])
-        )
-
-        # drift=1, threshold=max(1,0)=1, 1>1 is false
-        result = _verify_playlist_size(
-            api, "playlist1", 0, 42, "test",
-        )
-        assert result == 1
+        with pytest.raises(PlaylistVerificationError):
+            execute_rotate(schedule, api)

--- a/tests/services/test_job_executor_rotate.py
+++ b/tests/services/test_job_executor_rotate.py
@@ -25,13 +25,11 @@ from shuffify.spotify.exceptions import (
 from shuffify.enums import JobType
 
 
-# Rotate-executor tests need a Flask app context because the
-# executor calls TrackLockService.safe_get_locked_uris, which
-# touches db.session even in its except-branch fallback.
-@pytest.fixture(autouse=True)
-def _app_ctx(db_app):
-    with db_app.app_context():
-        yield
+# Executor paths touch TrackLockService.safe_get_locked_uris
+# (db.session) even in their except-branch fallback, so every
+# test in this module needs the shared app_ctx fixture
+# (defined in tests/conftest.py).
+pytestmark = pytest.mark.usefixtures("app_ctx")
 
 
 def _make_schedule(
@@ -1511,8 +1509,9 @@ class TestOperationOrdering:
         with patch.object(
             JobExecutorService, "_batch_add_tracks",
             side_effect=track_add,
-        ), patch.object(
-            JobExecutorService, "verify_playlist_state",
+        ), patch(
+            "shuffify.services.executors.rotate_executor"
+            ".verify_playlist_state",
             return_value=[],
         ):
             execute_rotate(schedule, api)

--- a/tests/services/test_job_executor_service.py
+++ b/tests/services/test_job_executor_service.py
@@ -19,6 +19,15 @@ from shuffify.services.executors.shuffle_executor import (
 )
 
 
+# Executor paths touch TrackLockService (db.session) even
+# in their except-branch fallbacks, so all tests need a
+# Flask app context.
+@pytest.fixture(autouse=True)
+def _app_ctx(db_app):
+    with db_app.app_context():
+        yield
+
+
 @pytest.fixture
 def mock_schedule():
     """Create a mock Schedule model instance."""

--- a/tests/services/test_job_executor_service.py
+++ b/tests/services/test_job_executor_service.py
@@ -19,13 +19,10 @@ from shuffify.services.executors.shuffle_executor import (
 )
 
 
-# Executor paths touch TrackLockService (db.session) even
-# in their except-branch fallbacks, so all tests need a
-# Flask app context.
-@pytest.fixture(autouse=True)
-def _app_ctx(db_app):
-    with db_app.app_context():
-        yield
+# Executor paths touch TrackLockService (db.session) even in
+# their except-branch fallbacks, so every test in this module
+# needs the shared app_ctx fixture (defined in tests/conftest.py).
+pytestmark = pytest.mark.usefixtures("app_ctx")
 
 
 @pytest.fixture

--- a/tests/services/test_verify_playlist_state.py
+++ b/tests/services/test_verify_playlist_state.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for JobExecutorService.verify_playlist_state and
+PlaylistVerificationError.
+
+Covers:
+  - Exact match returns the actual URI list
+  - Count drift raises with structured missing/extra
+  - URI substitution (same count, wrong members) raises
+  - Duplicates honored — multiset semantics, not set
+  - Paginated re-fetch via mocked api.get_playlist_tracks
+  - skip_cache=True is forwarded to the API call
+  - Empty expected + empty actual is a clean pass
+  - exception attributes carry playlist_id / phase / schedule_id
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shuffify.services.executors import (
+    JobExecutorService,
+    PlaylistVerificationError,
+)
+
+
+def _tracks(uris):
+    return [{"uri": u, "name": u} for u in uris]
+
+
+class TestVerifyPlaylistStateMatch:
+    def test_exact_match_returns_actual_uris(self):
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u2", "u3"]
+        )
+
+        result = JobExecutorService.verify_playlist_state(
+            api, "p1", ["u1", "u2", "u3"], 42, "test",
+        )
+
+        assert result == ["u1", "u2", "u3"]
+
+    def test_empty_expected_and_actual_passes(self):
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = []
+
+        result = JobExecutorService.verify_playlist_state(
+            api, "p1", [], 42, "empty",
+        )
+
+        assert result == []
+
+    def test_order_does_not_matter_for_match(self):
+        """Multiset compare ignores order."""
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u3", "u1", "u2"]
+        )
+
+        # No raise — same multiset.
+        JobExecutorService.verify_playlist_state(
+            api, "p1", ["u1", "u2", "u3"], 42, "test",
+        )
+
+    def test_skip_cache_is_forwarded(self):
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1"]
+        )
+
+        JobExecutorService.verify_playlist_state(
+            api, "p1", ["u1"], 42, "test",
+        )
+
+        api.get_playlist_tracks.assert_called_once_with(
+            "p1", skip_cache=True,
+        )
+
+
+class TestVerifyPlaylistStateDivergence:
+    def test_count_drift_raises_with_missing(self):
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u2"]
+        )
+
+        with pytest.raises(PlaylistVerificationError) as ex:
+            JobExecutorService.verify_playlist_state(
+                api, "p1",
+                ["u1", "u2", "u3"], 42, "swap",
+            )
+
+        assert ex.value.missing == ["u3"]
+        assert ex.value.extra == []
+        assert ex.value.playlist_id == "p1"
+        assert ex.value.phase == "swap"
+        assert ex.value.schedule_id == 42
+
+    def test_count_drift_raises_with_extra(self):
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u2", "u3", "u4"]
+        )
+
+        with pytest.raises(PlaylistVerificationError) as ex:
+            JobExecutorService.verify_playlist_state(
+                api, "p1",
+                ["u1", "u2"], 42, "swap",
+            )
+
+        assert sorted(ex.value.extra) == ["u3", "u4"]
+        assert ex.value.missing == []
+
+    def test_uri_substitution_raises(self):
+        """Same count, different members — count-only
+        verifier (the old one) would silently pass.
+        Multiset compare catches it.
+        """
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u2", "u4"]  # u3 → u4
+        )
+
+        with pytest.raises(PlaylistVerificationError) as ex:
+            JobExecutorService.verify_playlist_state(
+                api, "p1",
+                ["u1", "u2", "u3"], 42, "swap",
+            )
+
+        assert ex.value.missing == ["u3"]
+        assert ex.value.extra == ["u4"]
+
+    def test_duplicates_in_expected_must_match_actual(self):
+        """Multiset semantics: 2 copies expected, 1 actual
+        is a missing.
+        """
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u2"]
+        )
+
+        with pytest.raises(PlaylistVerificationError) as ex:
+            JobExecutorService.verify_playlist_state(
+                api, "p1",
+                ["u1", "u1", "u2"], 42, "shuffle",
+            )
+
+        assert ex.value.missing == ["u1"]
+        assert ex.value.extra == []
+
+    def test_duplicates_in_actual_count_as_extra(self):
+        """1 copy expected, 2 actual is an extra."""
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u1", "u2"]
+        )
+
+        with pytest.raises(PlaylistVerificationError) as ex:
+            JobExecutorService.verify_playlist_state(
+                api, "p1",
+                ["u1", "u2"], 42, "shuffle",
+            )
+
+        assert ex.value.missing == []
+        assert ex.value.extra == ["u1"]
+
+    def test_exception_message_contains_counts(self):
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = _tracks(
+            ["u1", "u2"]
+        )
+
+        with pytest.raises(PlaylistVerificationError) as ex:
+            JobExecutorService.verify_playlist_state(
+                api, "p1",
+                ["u1", "u2", "u3"], 42, "swap",
+            )
+
+        msg = str(ex.value)
+        assert "expected 3 tracks" in msg
+        assert "got 2" in msg
+        assert "missing 1" in msg
+        assert "Schedule 42" in msg
+        assert "swap" in msg
+
+
+class TestVerifyPlaylistStateAPIResilience:
+    def test_handles_none_returned_from_api(self):
+        """Some Spotify cache miss paths can yield None;
+        treat as empty.
+        """
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = None
+
+        result = JobExecutorService.verify_playlist_state(
+            api, "p1", [], 42, "test",
+        )
+
+        assert result == []
+
+    def test_filters_tracks_without_uri(self):
+        """Spotify can return placeholder items missing a
+        URI (e.g. local tracks). Those don't count toward
+        the actual set.
+        """
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = [
+            {"uri": "u1", "name": "u1"},
+            {"uri": None, "name": "local"},
+            {"name": "broken"},
+            {"uri": "u2", "name": "u2"},
+        ]
+
+        result = JobExecutorService.verify_playlist_state(
+            api, "p1", ["u1", "u2"], 42, "test",
+        )
+
+        assert result == ["u1", "u2"]

--- a/tests/services/test_verify_playlist_state.py
+++ b/tests/services/test_verify_playlist_state.py
@@ -1,5 +1,5 @@
 """
-Unit tests for JobExecutorService.verify_playlist_state and
+Unit tests for verify_playlist_state and
 PlaylistVerificationError.
 
 Covers:
@@ -18,8 +18,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from shuffify.services.executors import (
-    JobExecutorService,
     PlaylistVerificationError,
+    verify_playlist_state,
 )
 
 
@@ -34,7 +34,7 @@ class TestVerifyPlaylistStateMatch:
             ["u1", "u2", "u3"]
         )
 
-        result = JobExecutorService.verify_playlist_state(
+        result = verify_playlist_state(
             api, "p1", ["u1", "u2", "u3"], 42, "test",
         )
 
@@ -44,7 +44,7 @@ class TestVerifyPlaylistStateMatch:
         api = MagicMock()
         api.get_playlist_tracks.return_value = []
 
-        result = JobExecutorService.verify_playlist_state(
+        result = verify_playlist_state(
             api, "p1", [], 42, "empty",
         )
 
@@ -58,7 +58,7 @@ class TestVerifyPlaylistStateMatch:
         )
 
         # No raise — same multiset.
-        JobExecutorService.verify_playlist_state(
+        verify_playlist_state(
             api, "p1", ["u1", "u2", "u3"], 42, "test",
         )
 
@@ -68,7 +68,7 @@ class TestVerifyPlaylistStateMatch:
             ["u1"]
         )
 
-        JobExecutorService.verify_playlist_state(
+        verify_playlist_state(
             api, "p1", ["u1"], 42, "test",
         )
 
@@ -85,7 +85,7 @@ class TestVerifyPlaylistStateDivergence:
         )
 
         with pytest.raises(PlaylistVerificationError) as ex:
-            JobExecutorService.verify_playlist_state(
+            verify_playlist_state(
                 api, "p1",
                 ["u1", "u2", "u3"], 42, "swap",
             )
@@ -103,7 +103,7 @@ class TestVerifyPlaylistStateDivergence:
         )
 
         with pytest.raises(PlaylistVerificationError) as ex:
-            JobExecutorService.verify_playlist_state(
+            verify_playlist_state(
                 api, "p1",
                 ["u1", "u2"], 42, "swap",
             )
@@ -122,7 +122,7 @@ class TestVerifyPlaylistStateDivergence:
         )
 
         with pytest.raises(PlaylistVerificationError) as ex:
-            JobExecutorService.verify_playlist_state(
+            verify_playlist_state(
                 api, "p1",
                 ["u1", "u2", "u3"], 42, "swap",
             )
@@ -140,7 +140,7 @@ class TestVerifyPlaylistStateDivergence:
         )
 
         with pytest.raises(PlaylistVerificationError) as ex:
-            JobExecutorService.verify_playlist_state(
+            verify_playlist_state(
                 api, "p1",
                 ["u1", "u1", "u2"], 42, "shuffle",
             )
@@ -156,7 +156,7 @@ class TestVerifyPlaylistStateDivergence:
         )
 
         with pytest.raises(PlaylistVerificationError) as ex:
-            JobExecutorService.verify_playlist_state(
+            verify_playlist_state(
                 api, "p1",
                 ["u1", "u2"], 42, "shuffle",
             )
@@ -171,7 +171,7 @@ class TestVerifyPlaylistStateDivergence:
         )
 
         with pytest.raises(PlaylistVerificationError) as ex:
-            JobExecutorService.verify_playlist_state(
+            verify_playlist_state(
                 api, "p1",
                 ["u1", "u2", "u3"], 42, "swap",
             )
@@ -192,7 +192,7 @@ class TestVerifyPlaylistStateAPIResilience:
         api = MagicMock()
         api.get_playlist_tracks.return_value = None
 
-        result = JobExecutorService.verify_playlist_state(
+        result = verify_playlist_state(
             api, "p1", [], 42, "test",
         )
 
@@ -211,7 +211,7 @@ class TestVerifyPlaylistStateAPIResilience:
             {"uri": "u2", "name": "u2"},
         ]
 
-        result = JobExecutorService.verify_playlist_state(
+        result = verify_playlist_state(
             api, "p1", ["u1", "u2"], 42, "test",
         )
 


### PR DESCRIPTION
## Summary

Second PR in the WOOKLYN silent-loss investigation
(`documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/`).
Combines **F1 (verifier wrapper)** and **F3 (rotate expected-URI math)**
into one PR — the two are interdependent and the F1 doc explicitly
deferred Phase 2's expected-URI shape to F3.

### What changed

- **New `JobExecutorService.verify_playlist_state`** — URI-multiset
  compare. Replaces `rotate_executor._verify_playlist_size` (the
  50%-tolerance count check that let the 5/13 WOOKLYN loss slip
  through as a successful job).
- **New `PlaylistVerificationError(JobExecutionError)`** — raised on
  any divergence, carries `expected` / `actual` / `missing` / `extra` /
  `playlist_id` / `phase` / `schedule_id` for downstream rollback (F2)
  and Sentry capture (F5).
- **Wired into every write path:**
  - rotate Phase 1 overflow + archive
  - rotate Phase 2 swap + archive
  - shuffle
  - drip target + drip raid
  - raid pull (and dropped its silent `try/except → warning`)
- **F3 — correct rotate Phase 2 baseline**: computes
  `(prod ∖ swap_out) ∪ swap_in` instead of the original
  `len(prod_uris)`. Old baseline was wrong whenever locks /
  `protect_count` / depleted eligible pool made `swap_in` and
  `swap_out` differ in length.
- **Cache bypass:** verify reads use `skip_cache=True` on
  `get_playlist_tracks` (kwarg already supported, no API change
  needed). Post-write reads cannot return a cached pre-write state.

### Smoking-gun this catches

```
2026-05-13 09:00:09 UTC
WARNI [shuffify.services.executors.rotate_executor]
Schedule 11: swap size mismatch — expected 241 tracks, got 240
```

Under the old verifier this stayed a warning and the job was marked
`success`. Under the new verifier it would have raised
`PlaylistVerificationError` and the schedule would have failed loudly.
F2 (next PR) will turn the failure into an automatic snapshot
rollback.

### Test changes

- **New `tests/services/test_verify_playlist_state.py`** — 12 cases
  covering match, count drift, URI substitution, duplicate-multiset
  semantics, paginated fetch, `skip_cache` forwarding, exception
  attributes.
- **Legacy `TestVerifyPlaylistSizeDrift` removed** — its 4 tests
  documented the loose-verify behavior we're explicitly replacing.
- **`_make_api` fixture upgraded to a stateful mock** — applies
  `playlist_add_items` / `playlist_remove_items` to internal state so
  the post-write verify reads back what the executor actually wrote.
  The `post_removal_prod` kwarg is retained only for explicit
  divergence-simulation tests.
- **Two pre-existing latent bugs fixed along the way:**
  1. Executor test files needed a Flask app context (added autouse
     `db_app` fixture) — `TrackLockService.safe_get_locked_uris`
     touches `db.session` even in its except-branch fallback, so any
     test that triggered the fallback raised `RuntimeError: Working
     outside of application context`. These tests were silently failing
     on `main` before this PR.
  2. `get_tracks_side_effect` helpers in drip tests missing the
     `skip_cache=False` kwarg added when the verifier started using it.
- **Two old rotate tests rewritten** — `test_overflow_returns_verified_total`
  and `test_swap_returns_verified_total` previously documented the old
  loose-verify behavior; they now assert `PlaylistVerificationError` is
  raised.

## Test plan

- [x] `flake8 shuffify/` clean
- [x] `flake8 tests/services/test_*.py` clean (touched files)
- [x] `pytest tests/services/test_verify_playlist_state.py -v` — 12/12 pass
- [x] `pytest tests/services/test_job_executor_rotate.py` — 49/49 pass (was 19/49 on main due to latent app-context bug)
- [x] `pytest tests/services/test_drip_executor.py` — 6/6 pass
- [x] `pytest tests/services/test_job_executor_service.py` — 8/8 pass
- [x] **Full `pytest tests/` — 1792 passed, 1 skipped (11:18)**
- [ ] User to manually run F6's forensic SQL against Neon and confirm any pending WOOKLYN snapshots are restorable; this PR makes future rotations fail-safe but does not retroactively fix prior losses

## Followups

Item 2/5 of the investigation. Remaining:

- **F2** — Auto-rollback from snapshot on `PlaylistVerificationError` (catches the new exception and re-applies the pre-snapshot, marks `status='failed_rolled_back'`)
- **F4** — Tighten `update_playlist_tracks` / `_batch_add_tracks` to raise on per-batch HTTP failures (`SpotifyPartialBatchError`)
- **F5** — Initialize Sentry in app factory + APScheduler scope tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)