### PR TITLE
F2: auto-rollback from snapshot on PlaylistVerificationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Auto-rollback from snapshot on verification failure** - Closes the silent-loss loop: when `PlaylistVerificationError` fires (from the strict verifier shipped earlier), the executor now restores the playlist to its pre-job auto-snapshot instead of leaving it in a broken state
+  - `JobExecutorService.execute` catches `PlaylistVerificationError` and routes to `_record_rollback` (new); all other exceptions still go to `_record_failure` unchanged
+  - Pre-snapshots created during the job are discovered post-hoc via `(user_id, created_at >= execution.started_at)` rather than threading IDs through executor return values — works for shuffle, rotate, drip (dual target+raid), raid, and any future executor without per-executor changes
+  - When multiple snapshots exist for the same playlist (e.g. rotate snapshotting prod + archive), the latest per playlist wins
+  - `JobExecution.status` set to `failed_rolled_back`; `Schedule.last_status` mirrors it; `execute_now` raises `JobExecutionError` for the new status so the UI surfaces it
+  - New `PlaylistSnapshotService.restore_to_playlist(snapshot_id, user_id, api)` convenience that wraps `get_snapshot` + `api.update_playlist_tracks` and returns the applied snapshot
+  - New `ActivityType.SCHEDULE_RUN_ROLLED_BACK` activity entry carries a structured payload: `phase`, `failing_playlist_id`, `expected_count`, `actual_count`, `missing_total`, `extra_total`, `missing_uris[:50]`, `extra_uris[:50]`, and `restored[]` (one record per playlist)
+  - Restoration failure (Spotify down, snapshot missing) falls through to `_record_failure` so the user still sees the failure rather than a silently-broken job
+  - 11 new tests in `tests/services/test_snapshot_rollback.py` covering restore, status transitions, structured payload, snapshot-time-window filtering, no-snapshot fallback, dual-playlist restore for drip, latest-snapshot-per-playlist precedence, restore-failure fallthrough, and execute() routing for both PVE and non-PVE exceptions
+  - Third deliverable in the WOOKLYN silent-loss investigation; combines with the strict verifier to give defense-in-depth: verify catches the bug, rollback un-does the damage
+
 ### Fixed
 - **Strict post-write playlist verification** - Replaces rotate executor's 50%-tolerance count check with `JobExecutorService.verify_playlist_state` URI-multiset compare across all executors
   - Captured a real silent loss on 2026-05-13 (WOOKLYN, Schedule 11: `swap size mismatch — expected 241 tracks, got 240`). The old verifier only warned because drift was <50%; the new verifier raises `PlaylistVerificationError` for any divergence (missing tracks, extra tracks, or substitutions).

--- a/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/02_snapshot_rollback.md
+++ b/documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/02_snapshot_rollback.md
@@ -1,9 +1,27 @@
 # F2 — Auto-rollback from snapshot on verification failure
 
+**Status:** COMPLETE — Started 2026-05-17
 **Investigation:** [00_INVESTIGATION.md](00_INVESTIGATION.md)
 **Targets:** RC6 (snapshots taken but unused), RC7 (audit-trail divergence)
 **Depends on:** F1 (`PlaylistVerificationError` and `verify_playlist_state` exist)
 **Risk:** Medium. Effort: Medium.
+
+## Implementation note
+
+The plan's section A (threading `_rollback_snapshots` through every executor
+return dict) was skipped in favor of plan section D (post-hoc snapshot lookup)
+as the **primary** path. The post-hoc query
+`PlaylistSnapshot.query.filter(user_id == X, created_at >= execution.started_at)`
+correctly captures every auto-snapshot taken during the job — including drip's
+two snapshots (target + raid) and rotate's two snapshots (prod + archive) —
+without per-executor changes. This is DRYer, automatically robust against
+future executors that someone adds without reading this doc, and removes ~80
+lines of threading code that would have lived in four executor files.
+
+`JobExecution.error_metadata_json` column was NOT added — the existing
+`error_message` field (1000 chars, str(PVE) summary) is enough for status
+display, and the full structured diff lives on the `ActivityLog` row's
+`metadata_json`. No migration required.
 
 ## Context
 

--- a/shuffify/enums.py
+++ b/shuffify/enums.py
@@ -77,6 +77,7 @@ class ActivityType(StrEnum):
     SCHEDULE_DELETE = "schedule_delete"
     SCHEDULE_TOGGLE = "schedule_toggle"
     SCHEDULE_RUN = "schedule_run"
+    SCHEDULE_RUN_ROLLED_BACK = "schedule_run_rolled_back"
     SNAPSHOT_CREATE = "snapshot_create"
     SNAPSHOT_RESTORE = "snapshot_restore"
     SNAPSHOT_DELETE = "snapshot_delete"

--- a/shuffify/services/executors/base_executor.py
+++ b/shuffify/services/executors/base_executor.py
@@ -167,6 +167,10 @@ class JobExecutorService:
                 execution, schedule, result
             )
 
+        except PlaylistVerificationError as ve:
+            JobExecutorService._record_rollback(
+                execution, schedule, api, ve, schedule_id,
+            )
         except Exception as e:
             JobExecutorService._record_failure(
                 execution, schedule, e, schedule_id
@@ -293,6 +297,176 @@ class JobExecutorService:
             db.session.rollback()
 
     @staticmethod
+    def _record_rollback(
+        execution: JobExecution,
+        schedule: Schedule,
+        api: SpotifyAPI,
+        ve: "PlaylistVerificationError",
+        schedule_id: int,
+    ) -> None:
+        """Handle a PlaylistVerificationError by restoring the
+        auto-snapshots taken during this job, marking the
+        execution `failed_rolled_back`, and emitting a
+        structured ActivityLog entry.
+
+        If restoration itself fails (Spotify down, snapshot
+        missing), falls through to `_record_failure` so the
+        execution is still recorded as failed.
+        """
+        from shuffify.services.playlist_snapshot_service import (  # noqa: E501
+            PlaylistSnapshotService,
+            PlaylistSnapshotError,
+        )
+        from shuffify.models.db import PlaylistSnapshot
+
+        logger.error(
+            "Schedule %s: verification failed in phase "
+            "'%s' on playlist %s — attempting snapshot "
+            "rollback. Missing=%d, extra=%d.",
+            schedule_id, ve.phase, ve.playlist_id,
+            len(ve.missing), len(ve.extra),
+        )
+
+        restored = []
+        try:
+            user_id = (
+                schedule.user_id if schedule else None
+            )
+            since = (
+                execution.started_at if execution else None
+            )
+            if not user_id or not since:
+                raise PlaylistSnapshotError(
+                    "Missing user_id or job start time; "
+                    "cannot scope snapshots."
+                )
+
+            # All auto-snapshots created since the job
+            # started belong to this run.
+            pre_snapshots = (
+                PlaylistSnapshot.query
+                .filter(
+                    PlaylistSnapshot.user_id == user_id,
+                    PlaylistSnapshot.created_at >= since,
+                )
+                .order_by(
+                    PlaylistSnapshot.created_at.asc()
+                )
+                .all()
+            )
+
+            if not pre_snapshots:
+                raise PlaylistSnapshotError(
+                    "No pre-snapshot available for "
+                    "rollback (auto-snapshots disabled "
+                    "or empty source playlists)."
+                )
+
+            # One snapshot per playlist — restore the most
+            # recent if multiple were taken.
+            latest_by_playlist = {}
+            for snap in pre_snapshots:
+                latest_by_playlist[snap.playlist_id] = snap
+
+            for playlist_id, snap in (
+                latest_by_playlist.items()
+            ):
+                applied = (
+                    PlaylistSnapshotService
+                    .restore_to_playlist(
+                        snap.id, user_id, api,
+                    )
+                )
+                restored.append(
+                    {
+                        "playlist_id": playlist_id,
+                        "snapshot_id": snap.id,
+                        "track_count": (
+                            applied.track_count
+                        ),
+                    }
+                )
+        except Exception as restore_err:
+            logger.error(
+                "Schedule %s: rollback failed: %s. "
+                "Falling back to plain failure.",
+                schedule_id, restore_err, exc_info=True,
+            )
+            JobExecutorService._record_failure(
+                execution, schedule, ve, schedule_id,
+            )
+            return
+
+        # Persist the rolled-back status
+        try:
+            if execution:
+                execution.status = "failed_rolled_back"
+                execution.completed_at = datetime.now(
+                    timezone.utc
+                )
+                execution.error_message = str(ve)[:1000]
+
+            if schedule:
+                schedule.last_run_at = datetime.now(
+                    timezone.utc
+                )
+                schedule.last_status = (
+                    "failed_rolled_back"
+                )
+                schedule.last_error = str(ve)[:1000]
+
+            db.session.commit()
+        except Exception as db_err:
+            logger.error(
+                "Schedule %s: failed to persist "
+                "rollback status: %s",
+                schedule_id, db_err,
+            )
+            db.session.rollback()
+
+        # Log a structured activity entry (non-blocking).
+        try:
+            from shuffify.services.activity_log_service import (  # noqa: E501
+                ActivityLogService,
+            )
+
+            ActivityLogService.log(
+                user_id=schedule.user_id,
+                activity_type=(
+                    ActivityType.SCHEDULE_RUN_ROLLED_BACK
+                ),
+                description=(
+                    "Scheduled "
+                    f"{schedule.job_type} on "
+                    f"'{schedule.target_playlist_name}'"
+                    f" rolled back after verification "
+                    f"failure"
+                ),
+                playlist_id=schedule.target_playlist_id,
+                playlist_name=(
+                    schedule.target_playlist_name
+                ),
+                metadata={
+                    "schedule_id": schedule.id,
+                    "job_type": schedule.job_type,
+                    "phase": ve.phase,
+                    "failing_playlist_id": (
+                        ve.playlist_id
+                    ),
+                    "expected_count": len(ve.expected),
+                    "actual_count": len(ve.actual),
+                    "missing_total": len(ve.missing),
+                    "extra_total": len(ve.extra),
+                    "missing_uris": ve.missing[:50],
+                    "extra_uris": ve.extra[:50],
+                    "restored": restored,
+                    "triggered_by": "scheduler",
+                },
+            )
+        except Exception:
+            pass
+
+    @staticmethod
     def execute_now(
         schedule_id: int, user_id: int
     ) -> dict:
@@ -323,7 +497,9 @@ class JobExecutorService:
         db.session.expire(schedule)
         db.session.refresh(schedule)
 
-        if schedule.last_status == "failed":
+        if schedule.last_status in (
+            "failed", "failed_rolled_back",
+        ):
             raise JobExecutionError(
                 schedule.last_error or "Unknown error"
             )

--- a/shuffify/services/playlist_snapshot_service.py
+++ b/shuffify/services/playlist_snapshot_service.py
@@ -178,6 +178,43 @@ class PlaylistSnapshotService:
         return snapshot.track_uris
 
     @staticmethod
+    def restore_to_playlist(
+        snapshot_id: int,
+        user_id: int,
+        api,
+    ) -> "PlaylistSnapshot":
+        """Restore a snapshot to its source playlist via the
+        Spotify API. Used by the executor rollback path.
+
+        Args:
+            snapshot_id: The snapshot database ID.
+            user_id: The internal database user ID (ownership).
+            api: SpotifyAPI client.
+
+        Returns:
+            The PlaylistSnapshot that was applied (caller can
+            read playlist_id, track_uris, track_count).
+
+        Raises:
+            PlaylistSnapshotNotFoundError: If not found or not
+                owned.
+            Whatever the Spotify API raises on write failure.
+        """
+        snapshot = PlaylistSnapshotService.get_snapshot(
+            snapshot_id, user_id
+        )
+        uris = snapshot.track_uris or []
+        api.update_playlist_tracks(
+            snapshot.playlist_id, uris
+        )
+        logger.info(
+            "Restored snapshot %s to playlist %s "
+            "(%d tracks)",
+            snapshot_id, snapshot.playlist_id, len(uris),
+        )
+        return snapshot
+
+    @staticmethod
     def delete_snapshot(
         snapshot_id: int, user_id: int
     ) -> bool:

--- a/tests/services/test_snapshot_rollback.py
+++ b/tests/services/test_snapshot_rollback.py
@@ -1,0 +1,498 @@
+"""
+Tests for the snapshot rollback path triggered when an
+executor raises PlaylistVerificationError.
+
+Covers _record_rollback behavior on
+JobExecutorService.execute:
+    - Pre-snapshots created during the job are restored
+    - JobExecution.status set to failed_rolled_back
+    - Schedule.last_status set to failed_rolled_back
+    - ActivityLog entry has structured diff payload
+    - Drip's two pre-snapshots (target + raid) both restored
+    - When snapshot restoration itself fails, fall through to
+      _record_failure (status=failed, broken state preserved)
+    - Non-PlaylistVerificationError exceptions still go to
+      _record_failure unchanged
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shuffify.enums import (
+    ActivityType,
+    IntervalValue,
+    JobType,
+    ScheduleType,
+    SnapshotType,
+)
+from shuffify.models.db import (
+    ActivityLog,
+    JobExecution,
+    PlaylistSnapshot,
+    Schedule,
+    db,
+)
+from shuffify.services.executors import (
+    JobExecutorService,
+    PlaylistVerificationError,
+)
+from shuffify.services.playlist_snapshot_service import (
+    PlaylistSnapshotService,
+)
+from shuffify.services.user_service import UserService
+
+
+@pytest.fixture
+def user(db_app):
+    """Provide a test user."""
+    with db_app.app_context():
+        result = UserService.upsert_from_spotify(
+            {
+                "id": "rollbackuser",
+                "display_name": "Rollback User",
+                "images": [],
+            }
+        )
+        yield result.user
+
+
+@pytest.fixture
+def schedule(user):
+    sched = Schedule(
+        user_id=user.id,
+        job_type=JobType.SHUFFLE,
+        target_playlist_id="target_rb",
+        target_playlist_name="My Playlist",
+        schedule_type=ScheduleType.INTERVAL,
+        schedule_value=IntervalValue.DAILY,
+        algorithm_name="BasicShuffle",
+        is_enabled=True,
+    )
+    db.session.add(sched)
+    db.session.commit()
+    return sched
+
+
+def _make_pve(playlist_id="target_rb", schedule_id=1):
+    """Build a PlaylistVerificationError with a known
+    missing/extra diff."""
+    return PlaylistVerificationError(
+        playlist_id=playlist_id,
+        expected=["u1", "u2", "u3"],
+        actual=["u1", "u2", "u4"],
+        schedule_id=schedule_id,
+        phase="shuffle",
+    )
+
+
+def _make_api():
+    """Mock SpotifyAPI for rollback calls."""
+    api = MagicMock()
+    api.update_playlist_tracks.return_value = True
+    return api
+
+
+def _seed_snapshot(
+    user_id, playlist_id, uris,
+    snapshot_type=SnapshotType.SCHEDULED_PRE_EXECUTION,
+):
+    """Seed a PlaylistSnapshot row directly (bypassing
+    create_snapshot's retention enforcement which is
+    irrelevant here)."""
+    snap = PlaylistSnapshot(
+        user_id=user_id,
+        playlist_id=playlist_id,
+        playlist_name=playlist_id,
+        track_count=len(uris),
+        snapshot_type=snapshot_type,
+        trigger_description="test seed",
+    )
+    snap.track_uris = uris
+    db.session.add(snap)
+    db.session.commit()
+    return snap
+
+
+class TestRollbackRestoresPreSnapshot:
+    """Happy path: PVE → snapshot restored → status set."""
+
+    def test_rollback_restores_pre_snapshot_uris(
+        self, user, schedule,
+    ):
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        snap = _seed_snapshot(
+            user.id, "target_rb",
+            ["u1", "u2", "u3"],
+        )
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        api.update_playlist_tracks.assert_called_once_with(
+            "target_rb", ["u1", "u2", "u3"],
+        )
+        assert snap.id is not None
+
+    def test_status_set_to_failed_rolled_back(
+        self, user, schedule,
+    ):
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        _seed_snapshot(
+            user.id, "target_rb",
+            ["u1", "u2", "u3"],
+        )
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        db.session.refresh(execution)
+        db.session.refresh(schedule)
+        assert execution.status == "failed_rolled_back"
+        assert schedule.last_status == (
+            "failed_rolled_back"
+        )
+        assert execution.error_message is not None
+
+    def test_activity_log_payload(self, user, schedule):
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        snap = _seed_snapshot(
+            user.id, "target_rb",
+            ["u1", "u2", "u3"],
+        )
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        log = (
+            ActivityLog.query
+            .filter_by(
+                user_id=user.id,
+                activity_type=(
+                    ActivityType.SCHEDULE_RUN_ROLLED_BACK
+                ),
+            )
+            .first()
+        )
+        assert log is not None
+        meta = log.metadata_json
+        assert meta["phase"] == "shuffle"
+        assert meta["failing_playlist_id"] == "target_rb"
+        assert meta["expected_count"] == 3
+        assert meta["actual_count"] == 3
+        assert meta["missing_total"] == 1
+        assert meta["extra_total"] == 1
+        assert meta["missing_uris"] == ["u3"]
+        assert meta["extra_uris"] == ["u4"]
+        assert meta["restored"] == [
+            {
+                "playlist_id": "target_rb",
+                "snapshot_id": snap.id,
+                "track_count": 3,
+            }
+        ]
+
+
+class TestRollbackSnapshotLookup:
+    """The lookup uses (user_id, created_at >=
+    execution.started_at)."""
+
+    def test_only_snapshots_after_job_start_restored(
+        self, user, schedule,
+    ):
+        """A snapshot older than the job start is NOT
+        treated as a pre-state for this run."""
+        # Pre-existing snapshot from a previous run.
+        old = _seed_snapshot(
+            user.id, "target_rb", ["old1", "old2"],
+        )
+        # Backdate it.
+        old.created_at = datetime(
+            2020, 1, 1, tzinfo=timezone.utc,
+        )
+        db.session.commit()
+
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        # In-run snapshot.
+        recent = _seed_snapshot(
+            user.id, "target_rb",
+            ["u1", "u2", "u3"],
+        )
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        api.update_playlist_tracks.assert_called_once_with(
+            "target_rb", ["u1", "u2", "u3"],
+        )
+        assert recent.id != old.id
+
+    def test_no_snapshot_falls_through_to_failure(
+        self, user, schedule,
+    ):
+        """No pre-snapshot in scope → _record_failure
+        path → status=failed, broken state preserved."""
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        api.update_playlist_tracks.assert_not_called()
+        db.session.refresh(execution)
+        assert execution.status == "failed"
+        # No activity-log entry for the rolled-back path.
+        log = (
+            ActivityLog.query
+            .filter_by(
+                activity_type=(
+                    ActivityType.SCHEDULE_RUN_ROLLED_BACK
+                ),
+            )
+            .first()
+        )
+        assert log is None
+
+
+class TestRollbackMultiPlaylist:
+    """Drip / rotate take two pre-snapshots — both restore."""
+
+    def test_drip_restores_both_target_and_raid(
+        self, user, schedule,
+    ):
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        _seed_snapshot(
+            user.id, "target_rb",
+            ["t1", "t2"],
+            snapshot_type=SnapshotType.AUTO_PRE_DRIP,
+        )
+        _seed_snapshot(
+            user.id, "raid_rb",
+            ["r1", "r2", "r3"],
+            snapshot_type=SnapshotType.AUTO_PRE_DRIP,
+        )
+
+        ve = _make_pve(
+            playlist_id="raid_rb",
+            schedule_id=schedule.id,
+        )
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        # Both playlists restored.
+        calls = api.update_playlist_tracks.call_args_list
+        applied = {c[0][0]: list(c[0][1]) for c in calls}
+        assert applied == {
+            "target_rb": ["t1", "t2"],
+            "raid_rb": ["r1", "r2", "r3"],
+        }
+
+    def test_latest_snapshot_per_playlist_wins(
+        self, user, schedule,
+    ):
+        """If two snapshots exist for the same playlist
+        (e.g., create_snapshot called twice in a single
+        run), restore the latest."""
+        api = _make_api()
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        _seed_snapshot(
+            user.id, "target_rb", ["v1"],
+        )
+        latest = _seed_snapshot(
+            user.id, "target_rb",
+            ["v2", "v3"],
+        )
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        api.update_playlist_tracks.assert_called_once_with(
+            "target_rb", ["v2", "v3"],
+        )
+        assert latest.track_count == 2
+
+
+class TestRollbackFailureFallthrough:
+    """If restoration itself fails, fall back to plain
+    failure (don't silently swallow the verify error)."""
+
+    def test_restore_api_failure_marks_failed(
+        self, user, schedule,
+    ):
+        api = _make_api()
+        api.update_playlist_tracks.side_effect = (
+            RuntimeError("spotify down")
+        )
+
+        execution = JobExecution(
+            schedule_id=schedule.id,
+            started_at=datetime.now(timezone.utc),
+            status="running",
+        )
+        db.session.add(execution)
+        db.session.commit()
+
+        _seed_snapshot(
+            user.id, "target_rb",
+            ["u1", "u2", "u3"],
+        )
+
+        ve = _make_pve(schedule_id=schedule.id)
+        JobExecutorService._record_rollback(
+            execution, schedule, api, ve, schedule.id,
+        )
+
+        db.session.refresh(execution)
+        assert execution.status == "failed"
+
+
+class TestExecuteDispatchOnPVE:
+    """End-to-end: execute() must catch PVE and route
+    through _record_rollback, not _record_failure."""
+
+    def test_execute_routes_pve_to_rollback(
+        self, user, schedule,
+    ):
+        """A PVE raised by the executor lands in
+        _record_rollback (not _record_failure)."""
+        with patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._get_spotify_api"
+        ) as mock_get_api, patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._execute_job_type"
+        ) as mock_exec, patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._record_rollback"
+        ) as mock_rb, patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._record_failure"
+        ) as mock_fail:
+            mock_get_api.return_value = _make_api()
+            ve = _make_pve(schedule_id=schedule.id)
+            mock_exec.side_effect = ve
+
+            JobExecutorService.execute(schedule.id)
+
+            mock_rb.assert_called_once()
+            mock_fail.assert_not_called()
+
+    def test_execute_routes_other_errors_to_failure(
+        self, user, schedule,
+    ):
+        """A non-PVE exception still goes to
+        _record_failure."""
+        with patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._get_spotify_api"
+        ) as mock_get_api, patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._execute_job_type"
+        ) as mock_exec, patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._record_rollback"
+        ) as mock_rb, patch(
+            "shuffify.services.executors.base_executor"
+            ".JobExecutorService._record_failure"
+        ) as mock_fail:
+            mock_get_api.return_value = _make_api()
+            mock_exec.side_effect = RuntimeError("boom")
+
+            JobExecutorService.execute(schedule.id)
+
+            mock_fail.assert_called_once()
+            mock_rb.assert_not_called()
+
+
+class TestRestoreToPlaylistConvenience:
+    """The new PlaylistSnapshotService.restore_to_playlist
+    method (used by _record_rollback)."""
+
+    def test_restore_to_playlist_applies_and_returns(
+        self, user,
+    ):
+        api = _make_api()
+        snap = _seed_snapshot(
+            user.id, "p_restore",
+            ["a", "b", "c"],
+        )
+
+        applied = (
+            PlaylistSnapshotService.restore_to_playlist(
+                snap.id, user.id, api,
+            )
+        )
+
+        api.update_playlist_tracks.assert_called_once_with(
+            "p_restore", ["a", "b", "c"],
+        )
+        assert applied.id == snap.id
+        assert applied.playlist_id == "p_restore"
+        assert applied.track_count == 3


### PR DESCRIPTION
## Summary
- Catches `PlaylistVerificationError` from F1's strict verifier in `JobExecutorService.execute` and routes to a new `_record_rollback` that restores the playlist to its pre-job auto-snapshot
- Discovers in-flight snapshots via a post-hoc query `(user_id, created_at >= execution.started_at)` — handles drip's dual target+raid, rotate's prod+archive, shuffle's single playlist, and any future executor with no per-executor changes
- Sets `JobExecution.status = 'failed_rolled_back'` and emits an `ActivityType.SCHEDULE_RUN_ROLLED_BACK` entry with a structured diff payload (phase, expected/actual counts, missing/extra URIs, restored snapshots)
- New `PlaylistSnapshotService.restore_to_playlist(snapshot_id, user_id, api)` convenience used by the rollback path
- Restoration failure falls through to `_record_failure` so the user still sees the failure rather than a silently broken job
- Closes F2 in [the WOOKLYN silent-loss investigation](documentation/planning/investigations/wooklyn-silent-loss_2026-05-16/) — combines with F1 (verify) for full defense-in-depth: catch the bug → un-do the damage

## Test plan
- [x] `flake8 shuffify/` — clean
- [x] `pytest tests/services/test_snapshot_rollback.py -v` — 11/11 passed
- [x] `pytest tests/ -q` — 1803 passed, 1 skipped (was 1792 before this PR)
- [ ] Preview deploy: trigger a controlled rotation where one URI is yanked mid-flight; expect `JobExecution.status='failed_rolled_back'` and playlist restored to the pre-snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)