### PR TITLE
fix: remove hardcoded database credentials from docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,12 @@ REDIS_URL=redis://localhost:6379/0
 # The app automatically converts postgres:// to postgresql:// for SQLAlchemy.
 # DATABASE_URL=
 
+# ─── Docker Compose PostgreSQL ────────────────────────────────
+# Used by docker-compose.yml for the local PostgreSQL container.
+# Generate a password with: python -c "import secrets; print(secrets.token_hex(16))"
+POSTGRES_DB=shuffify_dev
+POSTGRES_USER=shuffify
+POSTGRES_PASSWORD=change-me-to-a-random-password
+
 # ─── Server ───────────────────────────────────────────────────
 PORT=8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,15 +15,15 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_DB: shuffify_dev
-      POSTGRES_USER: shuffify
-      POSTGRES_PASSWORD: shuffify_dev_password
+      POSTGRES_DB: ${POSTGRES_DB:-shuffify_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-shuffify}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
     ports:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U shuffify -d shuffify_dev"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-shuffify} -d ${POSTGRES_DB:-shuffify_dev}"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Replace hardcoded `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` in `docker-compose.yml` with `${VAR:-default}` references resolved from `.env`
- Password uses `${POSTGRES_PASSWORD:?...}` to fail fast with a clear error if unset
- Healthcheck command also parameterized to stay consistent with runtime values
- Add `POSTGRES_*` variables to `.env.example` with placeholder password and generation instructions

## Test plan
- [ ] `cp .env.example .env` on a fresh clone, set `POSTGRES_PASSWORD`, run `docker-compose up` — DB starts with configured credentials
- [ ] Omit `POSTGRES_PASSWORD` from `.env` — `docker-compose up` fails with `Set POSTGRES_PASSWORD in .env`
- [ ] Omit all `POSTGRES_*` vars — defaults (`shuffify_dev`, `shuffify`) apply for DB name and user; password still required
- [ ] Healthcheck passes: `docker-compose ps` shows `db` as `healthy`

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)