### PR TITLE
security: add CSRF protection to all state-changing endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **CSRF protection on all state-changing endpoints** - Added Flask-WTF CSRFProtect to validate CSRF tokens on all POST/PUT/DELETE/PATCH requests, closing the CSRF vulnerability on 51 state-changing endpoints
+  - Flask-WTF CSRFProtect initialized globally in the app factory
+  - CSRF token exposed via `<meta name="csrf-token">` in `base.html`
+  - Global `fetch()` wrapper auto-injects `X-CSRFToken` header on mutating requests — zero changes needed to existing AJAX calls
+  - Hidden `csrf_token` fields added to the 3 HTML forms (settings, shuffle, undo) for defense in depth
+  - Dedicated `CSRFError` handler returns a clear "refresh the page" message
+  - CSRF disabled in test config (`WTF_CSRF_ENABLED = False`) so test suite is unaffected
+  - Closes #357
+
 ### Changed
 - **Source resolver hygiene — dead field removed, rollback hardening, characterization tests** - Low-priority cleanup chasing #314 and #315 in the scraper module
   - **L1 dead field**: `PublicScraperPathway._set_cached` no longer writes `ScrapedPlaylistCache.track_count`. The column has no reader anywhere in the codebase — every caller derives the count from `len(track_uris)` instead. The column is intentionally left in the schema for now; a future cleanup PR can drop it via Alembic migration once a few releases have shipped without writers. No migration in this PR

--- a/config.py
+++ b/config.py
@@ -82,9 +82,7 @@ class Config:
     # Tunable per-environment so production can dial down latency budget
     # without code changes. Retry/backoff constants live in the pathway
     # module since they're stable algorithmic knobs, not ops controls.
-    SOURCE_RESOLVER_TIMEOUT = int(
-        os.getenv("SOURCE_RESOLVER_TIMEOUT", "10")
-    )
+    SOURCE_RESOLVER_TIMEOUT = int(os.getenv("SOURCE_RESOLVER_TIMEOUT", "10"))
 
     # Database configuration
     SQLALCHEMY_DATABASE_URI = _resolve_database_url("sqlite:///shuffify.db")
@@ -102,12 +100,8 @@ class Config:
     # Sentry observability (no-op when SENTRY_DSN is empty)
     SENTRY_DSN = os.getenv("SENTRY_DSN", "")
     SENTRY_ENVIRONMENT = os.getenv("SENTRY_ENVIRONMENT", "production")
-    SENTRY_TRACES_SAMPLE_RATE = float(
-        os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.0")
-    )
-    SENTRY_PROFILES_SAMPLE_RATE = float(
-        os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0")
-    )
+    SENTRY_TRACES_SAMPLE_RATE = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
+    SENTRY_PROFILES_SAMPLE_RATE = float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0"))
     SENTRY_RELEASE = os.getenv("GIT_SHA", "")
 
     @classmethod
@@ -178,6 +172,7 @@ class TestConfig(Config):
 
     CONFIG_NAME = "testing"
     TESTING = True
+    WTF_CSRF_ENABLED = False
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     SCHEDULER_ENABLED = False
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 Flask>=3.1.3
 Flask-Session>=0.8.0
+Flask-WTF>=1.2.0
 python-dotenv==1.2.2
 gunicorn==26.0.0
 numpy>=2.4.4

--- a/shuffify/__init__.py
+++ b/shuffify/__init__.py
@@ -7,6 +7,7 @@ from flask_session import Session
 import redis
 from flask_limiter import Limiter
 from flask_migrate import Migrate
+from flask_wtf.csrf import CSRFProtect
 from config import config, validate_required_env_vars
 
 logging.basicConfig(level=logging.DEBUG)
@@ -278,15 +279,13 @@ def _strip_pii(event, hint):
     with a fixed redaction sentinel. Cookies and Authorization are
     stripped wholesale.
     """
+
     def _redact(obj):
         if isinstance(obj, dict):
             return {
                 k: (
                     "[Filtered]"
-                    if any(
-                        token in str(k).lower()
-                        for token in _SENTRY_PII_DENYLIST
-                    )
+                    if any(token in str(k).lower() for token in _SENTRY_PII_DENYLIST)
                     else _redact(v)
                 )
                 for k, v in obj.items()
@@ -329,24 +328,16 @@ def _init_sentry(config_class):
         )
         from sentry_sdk.integrations.logging import LoggingIntegration
     except ImportError as e:
-        logger.warning(
-            "sentry-sdk not installed: %s. Skipping Sentry init.", e
-        )
+        logger.warning("sentry-sdk not installed: %s. Skipping Sentry init.", e)
         return False
 
     release = getattr(config_class, "SENTRY_RELEASE", "") or None
 
     sentry_sdk.init(
         dsn=dsn,
-        environment=getattr(
-            config_class, "SENTRY_ENVIRONMENT", "production"
-        ),
-        traces_sample_rate=getattr(
-            config_class, "SENTRY_TRACES_SAMPLE_RATE", 0.0
-        ),
-        profiles_sample_rate=getattr(
-            config_class, "SENTRY_PROFILES_SAMPLE_RATE", 0.0
-        ),
+        environment=getattr(config_class, "SENTRY_ENVIRONMENT", "production"),
+        traces_sample_rate=getattr(config_class, "SENTRY_TRACES_SAMPLE_RATE", 0.0),
+        profiles_sample_rate=getattr(config_class, "SENTRY_PROFILES_SAMPLE_RATE", 0.0),
         send_default_pii=False,
         release=release,
         integrations=[
@@ -451,6 +442,7 @@ def create_app(config_name=None):
     logger.info("CONFIG_NAME: %s", app.config.get("CONFIG_NAME", config_name))
 
     # Initialize extensions
+    CSRFProtect(app)
     global _redis_client, _limiter
     _redis_client = _init_redis(app)
     Session(app)

--- a/shuffify/error_handlers.py
+++ b/shuffify/error_handlers.py
@@ -184,9 +184,7 @@ def handle_state_error(error: StateError):
 def handle_user_service_error(error: UserServiceError):
     """Handle user service errors."""
     logger.error(f"User service error: {error}")
-    return json_error_response(
-        "User operation failed.", 500
-    )
+    return json_error_response("User operation failed.", 500)
 
 
 def handle_user_not_found(error: UserNotFoundError):
@@ -200,9 +198,7 @@ def handle_workshop_session_not_found(
 ):
     """Handle workshop session not found."""
     logger.info(f"Workshop session not found: {error}")
-    return json_error_response(
-        "Saved session not found.", 404
-    )
+    return json_error_response("Saved session not found.", 404)
 
 
 def handle_workshop_session_limit(
@@ -218,9 +214,7 @@ def handle_workshop_session_error(
 ):
     """Handle general workshop session errors."""
     logger.error(f"Workshop session error: {error}")
-    return json_error_response(
-        "Workshop session operation failed.", 500
-    )
+    return json_error_response("Workshop session operation failed.", 500)
 
 
 def handle_upstream_source_not_found(
@@ -236,9 +230,7 @@ def handle_upstream_source_error(
 ):
     """Handle general upstream source errors."""
     logger.error(f"Upstream source error: {error}")
-    return json_error_response(
-        "Source operation failed.", 500
-    )
+    return json_error_response("Source operation failed.", 500)
 
 
 # =============================================================================
@@ -251,9 +243,7 @@ def handle_schedule_not_found(
 ):
     """Handle schedule not found errors."""
     logger.info(f"Schedule not found: {error}")
-    return json_error_response(
-        "Schedule not found.", 404
-    )
+    return json_error_response("Schedule not found.", 404)
 
 
 def handle_schedule_error(error: ScheduleError):
@@ -267,9 +257,7 @@ def handle_job_execution_error(
 ):
     """Handle job execution failures."""
     logger.error(f"Job execution error: {error}")
-    return json_error_response(
-        f"Job execution failed: {error}", 500
-    )
+    return json_error_response(f"Job execution failed: {error}", 500)
 
 
 # =============================================================================
@@ -282,9 +270,7 @@ def handle_spotify_token_expired(
 ):
     """Handle expired Spotify tokens."""
     logger.warning(f"Spotify token expired: {error}")
-    return json_error_response(
-        "Session expired. Please log in again.", 401
-    )
+    return json_error_response("Session expired. Please log in again.", 401)
 
 
 def handle_spotify_rate_limit(
@@ -293,14 +279,11 @@ def handle_spotify_rate_limit(
     """Handle Spotify API rate limiting."""
     logger.warning(f"Spotify rate limit: {error}")
     response, status = json_error_response(
-        "Spotify is rate limiting requests. "
-        "Please wait a moment and try again.",
+        "Spotify is rate limiting requests. Please wait a moment and try again.",
         429,
     )
     if hasattr(error, "retry_after") and error.retry_after:
-        response.headers["Retry-After"] = str(
-            error.retry_after
-        )
+        response.headers["Retry-After"] = str(error.retry_after)
     return response, status
 
 
@@ -309,9 +292,7 @@ def handle_spotify_not_found(
 ):
     """Handle Spotify resource not found."""
     logger.info(f"Spotify resource not found: {error}")
-    return json_error_response(
-        "Spotify resource not found.", 404
-    )
+    return json_error_response("Spotify resource not found.", 404)
 
 
 def handle_spotify_auth_error(
@@ -320,8 +301,7 @@ def handle_spotify_auth_error(
     """Handle Spotify authentication errors."""
     logger.warning(f"Spotify auth error: {error}")
     return json_error_response(
-        "Spotify authentication failed. "
-        "Please log in again.",
+        "Spotify authentication failed. Please log in again.",
         401,
     )
 
@@ -331,9 +311,7 @@ def handle_spotify_api_error(
 ):
     """Handle general Spotify API errors."""
     logger.error(f"Spotify API error: {error}")
-    return json_error_response(
-        "Spotify API error. Please try again.", 500
-    )
+    return json_error_response("Spotify API error. Please try again.", 500)
 
 
 def handle_spotify_error(error: SpotifyError):
@@ -348,6 +326,20 @@ def handle_spotify_error(error: SpotifyError):
 # =============================================================================
 # HTTP Error Codes
 # =============================================================================
+
+
+def handle_csrf_error(error):
+    """Handle CSRF validation failures."""
+    logger.warning(
+        "CSRF validation failed on %s %s: %s",
+        request.method,
+        request.path,
+        error,
+    )
+    return json_error_response(
+        "Your request could not be verified. Please refresh the page and try again.",
+        400,
+    )
 
 
 def handle_bad_request(error):
@@ -383,12 +375,9 @@ def handle_internal_error(error):
     if (
         request.path.startswith("/api/")
         or request.is_json
-        or request.headers.get("X-Requested-With")
-        == "XMLHttpRequest"
+        or request.headers.get("X-Requested-With") == "XMLHttpRequest"
     ):
-        return json_error_response(
-            "An unexpected error occurred.", 500
-        )
+        return json_error_response("An unexpected error occurred.", 500)
     # Render HTML error page for browser navigation
     return render_template("errors/500.html"), 500
 
@@ -409,9 +398,11 @@ def handle_rate_limit_exceeded(error):
         "Too many requests. Please wait a moment and try again.",
         429,
     )
-    retry_after = error.description if isinstance(
-        error.description, str
-    ) and error.description.isdigit() else None
+    retry_after = (
+        error.description
+        if isinstance(error.description, str) and error.description.isdigit()
+        else None
+    )
     if retry_after:
         response.headers["Retry-After"] = retry_after
     elif hasattr(error, "retry_after"):
@@ -426,7 +417,10 @@ def handle_rate_limit_exceeded(error):
 
 def register_error_handlers(app):
     """Register global error handlers with the Flask app."""
+    from flask_wtf.csrf import CSRFError
+
     handlers = [
+        (CSRFError, handle_csrf_error),
         (ValidationError, handle_validation_error),
         (AuthenticationError, handle_authentication_error),
         (TokenValidationError, handle_token_validation_error),

--- a/shuffify/templates/base.html
+++ b/shuffify/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}Shuffify{% endblock %}</title>
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
@@ -194,6 +195,33 @@
 
     <!-- Shared JavaScript -->
     <script src="/static/js/notifications.js"></script>
+
+    <!-- CSRF: auto-inject token on mutating fetch requests -->
+    <script>
+    (function() {
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (!meta) return;
+        var token = meta.getAttribute('content');
+        var _fetch = window.fetch;
+        window.fetch = function(url, opts) {
+            opts = opts || {};
+            var method = (opts.method || 'GET').toUpperCase();
+            if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
+                if (opts.headers instanceof Headers) {
+                    if (!opts.headers.has('X-CSRFToken')) {
+                        opts.headers.set('X-CSRFToken', token);
+                    }
+                } else {
+                    opts.headers = opts.headers || {};
+                    if (!opts.headers['X-CSRFToken']) {
+                        opts.headers['X-CSRFToken'] = token;
+                    }
+                }
+            }
+            return _fetch.call(this, url, opts);
+        };
+    })();
+    </script>
 
     <!-- JavaScript for AJAX operations -->
     <script>

--- a/shuffify/templates/macros/cards.html
+++ b/shuffify/templates/macros/cards.html
@@ -149,6 +149,7 @@
               action="{{ url_for('main.shuffle', playlist_id=playlist.id) }}"
               method="POST"
               data-playlist-id="{{ playlist.id }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="algorithm" class="shuffle-algorithm-input" value="BasicShuffle">
         </form>
 
@@ -158,6 +159,7 @@
               action="{{ url_for('main.undo', playlist_id=playlist.id) }}"
               method="POST"
               data-playlist-id="{{ playlist.id }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         </form>
     </div>
 

--- a/shuffify/templates/settings.html
+++ b/shuffify/templates/settings.html
@@ -23,6 +23,7 @@
     <!-- Settings Form -->
     <div class="relative max-w-3xl mx-auto px-4 py-6">
         <form id="settings-form" method="POST" action="{{ url_for('main.update_settings') }}" class="space-y-6">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <!-- Shuffle Defaults Section -->
             {% call glass_card('Shuffle Defaults') %}

--- a/tests/test_refresh_and_registry.py
+++ b/tests/test_refresh_and_registry.py
@@ -79,6 +79,7 @@ class TestRefreshPlaylistsRoute:
 
         app = create_app("development")
         app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
         return app
 
     @pytest.fixture
@@ -153,9 +154,7 @@ class TestRefreshPlaylistsRoute:
 
         client.post("/refresh-playlists")
 
-        mock_service.get_user_playlists.assert_called_once_with(
-            skip_cache=True
-        )
+        mock_service.get_user_playlists.assert_called_once_with(skip_cache=True)
 
     @patch("shuffify.is_db_available")
     @patch("shuffify.routes.get_db_user")
@@ -180,9 +179,7 @@ class TestRefreshPlaylistsRoute:
         mock_get_db_user.return_value = mock_user
 
         mock_service = Mock()
-        mock_service.get_user_playlists.side_effect = PlaylistError(
-            "API error"
-        )
+        mock_service.get_user_playlists.side_effect = PlaylistError("API error")
         mock_playlist_service_cls.return_value = mock_service
 
         response = client.post("/refresh-playlists")


### PR DESCRIPTION
## Summary

- Adds Flask-WTF `CSRFProtect` to validate CSRF tokens on all POST/PUT/DELETE/PATCH requests, closing the vulnerability on **51 state-changing endpoints**
- Global `fetch()` wrapper in `base.html` auto-injects `X-CSRFToken` header on mutating requests — zero changes needed to existing AJAX calls (~75 fetch calls covered)
- Hidden `csrf_token` fields added to 3 HTML forms (settings, shuffle, undo) for defense in depth
- Dedicated `CSRFError` handler returns a clear "refresh the page" message
- CSRF disabled in test config so existing test suite is unaffected (1869 pass, 0 fail)

## Approach

Flask-WTF CSRFProtect is the standard CSRF solution for Flask apps. The implementation uses a meta-tag + fetch-wrapper pattern so all existing AJAX calls are protected without individual modification. The fetch wrapper handles both plain object headers and `Headers` instances.

## Files changed

| File | Change |
|------|--------|
| `requirements/base.txt` | Add Flask-WTF>=1.2.0 |
| `shuffify/__init__.py` | Initialize CSRFProtect in app factory |
| `shuffify/error_handlers.py` | Add CSRFError handler + registration |
| `shuffify/templates/base.html` | CSRF meta tag + global fetch wrapper |
| `shuffify/templates/settings.html` | Hidden csrf_token input |
| `shuffify/templates/macros/cards.html` | Hidden csrf_token inputs (shuffle + undo forms) |
| `config.py` | WTF_CSRF_ENABLED = False in TestConfig |
| `tests/test_refresh_and_registry.py` | Disable CSRF in dev-config test fixture |
| `CHANGELOG.md` | Security entry for #357 |

## Test plan

- [x] `flake8 shuffify/` — 0 errors
- [x] `pytest tests/ -v` — 1869 passed, 0 failed
- [x] `/simplify` review completed — hardened fetch wrapper for Headers instances, fixed error message ambiguity, removed style inconsistency

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)