### PR TITLE
fix(security): strip health metrics, remove PG host port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CSRF disabled in test config (`WTF_CSRF_ENABLED = False`) so test suite is unaffected
   - Closes #357
 - **Session regenerated after OAuth login to prevent session fixation** — After successful Spotify OAuth callback, the session is now cleared and regenerated with a new session ID before storing authentication data. Previously, the pre-authentication session ID was preserved, allowing an attacker who planted a session cookie to hijack the authenticated session. The fix calls `session.clear()` after token exchange and user validation, then re-populates only the auth data — any pre-auth session state (including attacker-planted markers) is discarded. Closes #358.
+- **Health endpoint no longer exposes scheduler metrics** - The `/health` endpoint now returns only `status` and `timestamp`. Internal scheduler metrics (job counts, failure counts, last execution time) are stripped from the unauthenticated response. Closes #362
+- **PostgreSQL port no longer exposed to host network** - Removed host port mapping (`5432:5432`) from `docker-compose.yml` so the database is only reachable from other containers via Docker's internal network. Closes #363
 
 ### Changed
 - **Source resolver hygiene — dead field removed, rollback hardening, characterization tests** - Low-priority cleanup chasing #314 and #315 in the scraper module

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-shuffify_dev}
       POSTGRES_USER: ${POSTGRES_USER:-shuffify}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
-    ports:
-      - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/shuffify/routes/core.py
+++ b/shuffify/routes/core.py
@@ -147,23 +147,14 @@ def privacy():
 def health():
     """Health check endpoint for Docker and monitoring."""
     from shuffify import is_db_available
-    from shuffify.scheduler import get_scheduler_metrics
 
     db_healthy = is_db_available()
-    scheduler_metrics = get_scheduler_metrics()
-
-    # Degraded if DB is down or scheduler is not running
-    if not db_healthy:
-        overall_status = "degraded"
-    else:
-        overall_status = "healthy"
 
     return (
         jsonify(
             {
-                "status": overall_status,
+                "status": "healthy" if db_healthy else "degraded",
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-                "scheduler": scheduler_metrics,
             }
         ),
         200,

--- a/tests/test_health_db.py
+++ b/tests/test_health_db.py
@@ -54,23 +54,16 @@ class TestHealthEndpoint:
         assert "T" in data["timestamp"]
 
     def test_health_response_has_expected_keys(self, client):
-        """Health response should contain status, timestamp, and scheduler."""
+        """Health response should contain only status and timestamp."""
         response = client.get("/health")
         data = response.get_json()
         assert set(data.keys()) == {
             "status",
             "timestamp",
-            "scheduler",
         }
 
-    def test_health_scheduler_metrics_shape(self, client):
-        """Scheduler metrics should include expected fields."""
+    def test_health_does_not_expose_scheduler_metrics(self, client):
+        """Health response must NOT include scheduler metrics."""
         response = client.get("/health")
         data = response.get_json()
-        sched = data["scheduler"]
-        assert "scheduler_running" in sched
-        assert "jobs_executed" in sched
-        assert "jobs_failed" in sched
-        assert "jobs_missed" in sched
-        assert "last_execution_at" in sched
-        assert isinstance(sched["scheduler_running"], bool)
+        assert "scheduler" not in data


### PR DESCRIPTION
## Summary

- **#362** — `/health` endpoint no longer exposes internal scheduler metrics (job counts, failure counts, last execution time). Returns only `status` + `timestamp`, which is all Docker/load-balancer health checks need.
- **#363** — Removed `5432:5432` host port mapping from `docker-compose.yml` so PostgreSQL is only reachable via Docker's internal network, not from the host.

## Changes

| File | What |
|------|------|
| `shuffify/routes/core.py` | Strip `get_scheduler_metrics` import and `scheduler` key from response |
| `docker-compose.yml` | Remove `ports:` block from `db` service |
| `tests/test_health_db.py` | Update key-set assertion, replace metrics-shape test with negative assertion |
| `CHANGELOG.md` | Add Security entries for both fixes |

## Test plan

- [x] `pytest tests/test_health_db.py -v` — 8/8 pass
- [x] `pytest tests/ -v` — 1869 passed, 0 failed
- [x] `flake8 shuffify/routes/core.py` — clean
- [x] `/simplify` — all three review agents found no issues
- [ ] Verify `curl /health` returns only `{"status": "healthy", "timestamp": "..."}` in deployed environment
- [ ] Verify `docker-compose up` — app container can still reach DB via internal network

Closes #362, #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)