### PR TITLE
fix: tech-debt sweep — boundary validation, dead code, readability

### DIFF
--- a/shuffify/enums.py
+++ b/shuffify/enums.py
@@ -10,6 +10,7 @@ from enum import StrEnum
 
 class JobType(StrEnum):
     """Types of scheduled jobs."""
+
     RAID = "raid"
     SHUFFLE = "shuffle"
     RAID_AND_SHUFFLE = "raid_and_shuffle"
@@ -20,19 +21,20 @@ class JobType(StrEnum):
 
 class RotationMode(StrEnum):
     """Modes for the scheduled rotation job type."""
+
     SWAP = "swap"
-    # TODO: Re-implement archive_oldest mode (see git history)
-    # TODO: Re-implement refresh mode (see git history)
 
 
 class ScheduleType(StrEnum):
     """Schedule trigger types."""
+
     INTERVAL = "interval"
     CRON = "cron"
 
 
 class IntervalValue(StrEnum):
     """Predefined interval values for interval schedules."""
+
     EVERY_6H = "every_6h"
     EVERY_12H = "every_12h"
     DAILY = "daily"
@@ -42,6 +44,7 @@ class IntervalValue(StrEnum):
 
 class SnapshotType(StrEnum):
     """Types of playlist snapshots."""
+
     AUTO_PRE_SHUFFLE = "auto_pre_shuffle"
     AUTO_PRE_RAID = "auto_pre_raid"
     AUTO_PRE_COMMIT = "auto_pre_commit"
@@ -53,12 +56,14 @@ class SnapshotType(StrEnum):
 
 class LockTier(StrEnum):
     """Tiers for per-track playlist locks."""
+
     STANDARD = "standard"  # 30-day auto-expiry
-    SUPER = "super"        # permanent
+    SUPER = "super"  # permanent
 
 
 class PendingRaidStatus(StrEnum):
     """Status of a pending raid track."""
+
     PENDING = "pending"
     PROMOTED = "promoted"
     DISMISSED = "dismissed"
@@ -66,6 +71,7 @@ class PendingRaidStatus(StrEnum):
 
 class ActivityType(StrEnum):
     """Types of user activities tracked in the activity log."""
+
     SHUFFLE = "shuffle"
     WORKSHOP_COMMIT = "workshop_commit"
     WORKSHOP_SESSION_SAVE = "workshop_session_save"

--- a/shuffify/models/db.py
+++ b/shuffify/models/db.py
@@ -41,9 +41,7 @@ class User(db.Model):
     __tablename__ = "users"
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    spotify_id = db.Column(
-        db.String(255), unique=True, nullable=False, index=True
-    )
+    spotify_id = db.Column(db.String(255), unique=True, nullable=False, index=True)
     display_name = db.Column(db.String(255), nullable=True)
     email = db.Column(db.String(255), nullable=True)
     profile_image_url = db.Column(db.String(1024), nullable=True)
@@ -54,14 +52,10 @@ class User(db.Model):
 
     # Login tracking
     last_login_at = db.Column(db.DateTime, nullable=True)
-    login_count = db.Column(
-        db.Integer, nullable=False, default=0
-    )
+    login_count = db.Column(db.Integer, nullable=False, default=0)
 
     # Account status
-    is_active = db.Column(
-        db.Boolean, nullable=False, default=True
-    )
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
 
     # Extended Spotify profile fields
     country = db.Column(db.String(10), nullable=True)
@@ -123,25 +117,15 @@ class User(db.Model):
             "email": self.email,
             "profile_image_url": self.profile_image_url,
             "last_login_at": (
-                self.last_login_at.isoformat()
-                if self.last_login_at
-                else None
+                self.last_login_at.isoformat() if self.last_login_at else None
             ),
             "login_count": self.login_count,
             "is_active": self.is_active,
             "country": self.country,
             "spotify_product": self.spotify_product,
             "spotify_uri": self.spotify_uri,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     def __repr__(self) -> str:
@@ -158,9 +142,7 @@ class UserSettings(db.Model):
 
     __tablename__ = "user_settings"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
@@ -170,33 +152,19 @@ class UserSettings(db.Model):
     )
 
     # Shuffle defaults
-    default_algorithm = db.Column(
-        db.String(64), nullable=True
-    )
-    default_algorithm_params = db.Column(
-        db.JSON, nullable=True
-    )
+    default_algorithm = db.Column(db.String(64), nullable=True)
+    default_algorithm_params = db.Column(db.JSON, nullable=True)
 
     # UI preferences
-    theme = db.Column(
-        db.String(10), nullable=False, default="system"
-    )
+    theme = db.Column(db.String(10), nullable=False, default="system")
 
     # Feature toggles
-    notifications_enabled = db.Column(
-        db.Boolean, nullable=False, default=False
-    )
-    auto_snapshot_enabled = db.Column(
-        db.Boolean, nullable=False, default=True
-    )
-    max_snapshots_per_playlist = db.Column(
-        db.Integer, nullable=False, default=10
-    )
+    notifications_enabled = db.Column(db.Boolean, nullable=False, default=False)
+    auto_snapshot_enabled = db.Column(db.Boolean, nullable=False, default=True)
+    max_snapshots_per_playlist = db.Column(db.Integer, nullable=False, default=10)
 
     # Dashboard preferences
-    dashboard_show_recent_activity = db.Column(
-        db.Boolean, nullable=False, default=True
-    )
+    dashboard_show_recent_activity = db.Column(db.Boolean, nullable=False, default=True)
 
     # Extensible JSON field for future preferences
     extra = db.Column(db.JSON, nullable=True)
@@ -226,8 +194,7 @@ class UserSettings(db.Model):
             name="ck_user_settings_theme",
         ),
         db.CheckConstraint(
-            "max_snapshots_per_playlist >= 1 "
-            "AND max_snapshots_per_playlist <= 50",
+            "max_snapshots_per_playlist >= 1 AND max_snapshots_per_playlist <= 50",
             name="ck_user_settings_max_snapshots",
         ),
     )
@@ -238,38 +205,19 @@ class UserSettings(db.Model):
             "id": self.id,
             "user_id": self.user_id,
             "default_algorithm": self.default_algorithm,
-            "default_algorithm_params": (
-                self.default_algorithm_params or {}
-            ),
+            "default_algorithm_params": (self.default_algorithm_params or {}),
             "theme": self.theme,
             "notifications_enabled": self.notifications_enabled,
-            "auto_snapshot_enabled": (
-                self.auto_snapshot_enabled
-            ),
-            "max_snapshots_per_playlist": (
-                self.max_snapshots_per_playlist
-            ),
-            "dashboard_show_recent_activity": (
-                self.dashboard_show_recent_activity
-            ),
+            "auto_snapshot_enabled": (self.auto_snapshot_enabled),
+            "max_snapshots_per_playlist": (self.max_snapshots_per_playlist),
+            "dashboard_show_recent_activity": (self.dashboard_show_recent_activity),
             "extra": self.extra or {},
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     def __repr__(self) -> str:
-        return (
-            f"<UserSettings user_id={self.user_id} "
-            f"theme={self.theme}>"
-        )
+        return f"<UserSettings user_id={self.user_id} theme={self.theme}>"
 
 
 class WorkshopSession(db.Model):
@@ -308,11 +256,7 @@ class WorkshopSession(db.Model):
     user = db.relationship("User", back_populates="workshop_sessions")
 
     # Composite index for efficient lookup
-    __table_args__ = (
-        db.Index(
-            "ix_workshop_user_playlist", "user_id", "playlist_id"
-        ),
-    )
+    __table_args__ = (db.Index("ix_workshop_user_playlist", "user_id", "playlist_id"),)
 
     @property
     def track_uris(self) -> List[str]:
@@ -323,8 +267,7 @@ class WorkshopSession(db.Model):
             return json.loads(self.track_uris_json)
         except (json.JSONDecodeError, TypeError):
             logger.warning(
-                f"Failed to decode track_uris_json for "
-                f"WorkshopSession {self.id}"
+                f"Failed to decode track_uris_json for WorkshopSession {self.id}"
             )
             return []
 
@@ -342,16 +285,8 @@ class WorkshopSession(db.Model):
             "session_name": self.session_name,
             "track_uris": self.track_uris,
             "track_count": len(self.track_uris),
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     def __repr__(self) -> str:
@@ -377,14 +312,10 @@ class UpstreamSource(db.Model):
         nullable=False,
         index=True,
     )
-    target_playlist_id = db.Column(
-        db.String(255), nullable=False, index=True
-    )
+    target_playlist_id = db.Column(db.String(255), nullable=False, index=True)
     source_playlist_id = db.Column(db.String(255), nullable=True)
     source_url = db.Column(db.String(1024), nullable=True)
-    source_type = db.Column(
-        db.String(20), nullable=False, default="external"
-    )
+    source_type = db.Column(db.String(20), nullable=False, default="external")
     source_name = db.Column(db.String(255), nullable=True)
     search_query = db.Column(db.String(500), nullable=True)
     last_resolved_at = db.Column(db.DateTime, nullable=True)
@@ -393,9 +324,7 @@ class UpstreamSource(db.Model):
         db.String(20), nullable=True
     )  # "success", "partial", "failed"
     last_track_count = db.Column(db.Integer, nullable=True)
-    raid_count = db.Column(
-        db.Integer, nullable=False, default=5
-    )
+    raid_count = db.Column(db.Integer, nullable=False, default=5)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -412,8 +341,7 @@ class UpstreamSource(db.Model):
             "target_playlist_id",
         ),
         db.CheckConstraint(
-            "source_type IN ('own', 'external', "
-            "'search_query')",
+            "source_type IN ('own', 'external', 'search_query')",
             name="ck_upstream_source_type",
         ),
         db.CheckConstraint(
@@ -434,19 +362,13 @@ class UpstreamSource(db.Model):
             "source_name": self.source_name,
             "search_query": self.search_query,
             "last_resolved_at": (
-                self.last_resolved_at.isoformat()
-                if self.last_resolved_at
-                else None
+                self.last_resolved_at.isoformat() if self.last_resolved_at else None
             ),
             "last_resolve_pathway": self.last_resolve_pathway,
             "last_resolve_status": self.last_resolve_status,
             "last_track_count": self.last_track_count,
             "raid_count": self.raid_count,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
         }
 
     def __repr__(self) -> str:
@@ -476,35 +398,23 @@ class Schedule(db.Model):
         nullable=False,
         index=True,
     )
-    job_type = db.Column(
-        db.String(20), nullable=False
-    )
-    target_playlist_id = db.Column(
-        db.String(64), nullable=False
-    )
-    target_playlist_name = db.Column(
-        db.String(255), nullable=True
-    )
-    source_playlist_ids = db.Column(
-        db.JSON, nullable=True, default=list
-    )
-    algorithm_name = db.Column(
-        db.String(64), nullable=True
-    )
-    algorithm_params = db.Column(
-        db.JSON, nullable=True, default=dict
-    )
+    job_type = db.Column(db.String(20), nullable=False)
+    target_playlist_id = db.Column(db.String(64), nullable=False)
+    target_playlist_name = db.Column(db.String(255), nullable=True)
+    source_playlist_ids = db.Column(db.JSON, nullable=True, default=list)
+    algorithm_name = db.Column(db.String(64), nullable=True)
+    algorithm_params = db.Column(db.JSON, nullable=True, default=dict)
     schedule_type = db.Column(
-        db.String(10), nullable=False,
+        db.String(10),
+        nullable=False,
         default=ScheduleType.INTERVAL,
     )
     schedule_value = db.Column(
-        db.String(100), nullable=False,
+        db.String(100),
+        nullable=False,
         default=IntervalValue.DAILY,
     )
-    is_enabled = db.Column(
-        db.Boolean, nullable=False, default=True
-    )
+    is_enabled = db.Column(db.Boolean, nullable=False, default=True)
     last_run_at = db.Column(db.DateTime, nullable=True)
     last_status = db.Column(db.String(20), nullable=True)
     last_error = db.Column(db.Text, nullable=True)
@@ -540,23 +450,11 @@ class Schedule(db.Model):
             "schedule_type": self.schedule_type,
             "schedule_value": self.schedule_value,
             "is_enabled": self.is_enabled,
-            "last_run_at": (
-                self.last_run_at.isoformat()
-                if self.last_run_at
-                else None
-            ),
+            "last_run_at": (self.last_run_at.isoformat() if self.last_run_at else None),
             "last_status": self.last_status,
             "last_error": self.last_error,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     __table_args__ = (
@@ -607,12 +505,8 @@ class JobExecution(db.Model):
         default=lambda: datetime.now(timezone.utc),
     )
     completed_at = db.Column(db.DateTime, nullable=True)
-    status = db.Column(
-        db.String(20), nullable=False, default="running"
-    )
-    tracks_added = db.Column(
-        db.Integer, nullable=True, default=0
-    )
+    status = db.Column(db.String(20), nullable=False, default="running")
+    tracks_added = db.Column(db.Integer, nullable=True, default=0)
     tracks_total = db.Column(db.Integer, nullable=True)
     error_message = db.Column(db.Text, nullable=True)
 
@@ -627,15 +521,9 @@ class JobExecution(db.Model):
         return {
             "id": self.id,
             "schedule_id": self.schedule_id,
-            "started_at": (
-                self.started_at.isoformat()
-                if self.started_at
-                else None
-            ),
+            "started_at": (self.started_at.isoformat() if self.started_at else None),
             "completed_at": (
-                self.completed_at.isoformat()
-                if self.completed_at
-                else None
+                self.completed_at.isoformat() if self.completed_at else None
             ),
             "status": self.status,
             "tracks_added": self.tracks_added,
@@ -680,14 +568,11 @@ class LoginHistory(db.Model):
     login_type = db.Column(db.String(20), nullable=False)
 
     # Relationships
-    user = db.relationship(
-        "User", back_populates="login_history"
-    )
+    user = db.relationship("User", back_populates="login_history")
 
     __table_args__ = (
         db.CheckConstraint(
-            "login_type IN ('oauth_initial', "
-            "'oauth_refresh', 'session_resume')",
+            "login_type IN ('oauth_initial', 'oauth_refresh', 'session_resume')",
             name="ck_login_history_type",
         ),
     )
@@ -698,14 +583,10 @@ class LoginHistory(db.Model):
             "id": self.id,
             "user_id": self.user_id,
             "logged_in_at": (
-                self.logged_in_at.isoformat()
-                if self.logged_in_at
-                else None
+                self.logged_in_at.isoformat() if self.logged_in_at else None
             ),
             "logged_out_at": (
-                self.logged_out_at.isoformat()
-                if self.logged_out_at
-                else None
+                self.logged_out_at.isoformat() if self.logged_out_at else None
             ),
             "ip_address": self.ip_address,
             "user_agent": self.user_agent,
@@ -732,33 +613,23 @@ class PlaylistSnapshot(db.Model):
 
     __tablename__ = "playlist_snapshots"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
         index=True,
     )
-    playlist_id = db.Column(
-        db.String(255), nullable=False, index=True
-    )
-    playlist_name = db.Column(
-        db.String(255), nullable=False
-    )
+    playlist_id = db.Column(db.String(255), nullable=False, index=True)
+    playlist_name = db.Column(db.String(255), nullable=False)
     track_uris_json = db.Column(db.Text, nullable=False)
-    track_count = db.Column(
-        db.Integer, nullable=False, default=0
-    )
+    track_count = db.Column(db.Integer, nullable=False, default=0)
     snapshot_type = db.Column(
         db.String(30),
         nullable=False,
         default=SnapshotType.MANUAL,
     )
-    trigger_description = db.Column(
-        db.String(500), nullable=True
-    )
+    trigger_description = db.Column(db.String(500), nullable=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -768,9 +639,7 @@ class PlaylistSnapshot(db.Model):
     # Relationships
     user = db.relationship(
         "User",
-        backref=db.backref(
-            "playlist_snapshots", lazy="dynamic"
-        ),
+        backref=db.backref("playlist_snapshots", lazy="dynamic"),
     )
 
     __table_args__ = (
@@ -799,8 +668,7 @@ class PlaylistSnapshot(db.Model):
             return json.loads(self.track_uris_json)
         except (json.JSONDecodeError, TypeError):
             logger.warning(
-                f"Failed to decode track_uris_json for "
-                f"PlaylistSnapshot {self.id}"
+                f"Failed to decode track_uris_json for PlaylistSnapshot {self.id}"
             )
             return []
 
@@ -820,11 +688,7 @@ class PlaylistSnapshot(db.Model):
             "track_count": self.track_count,
             "snapshot_type": self.snapshot_type,
             "trigger_description": self.trigger_description,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
         }
 
     def __repr__(self) -> str:
@@ -848,27 +712,17 @@ class ActivityLog(db.Model):
 
     __tablename__ = "activity_log"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
         index=True,
     )
-    activity_type = db.Column(
-        db.String(50), nullable=False, index=True
-    )
-    description = db.Column(
-        db.String(500), nullable=False
-    )
-    playlist_id = db.Column(
-        db.String(255), nullable=True
-    )
-    playlist_name = db.Column(
-        db.String(255), nullable=True
-    )
+    activity_type = db.Column(db.String(50), nullable=False, index=True)
+    description = db.Column(db.String(500), nullable=False)
+    playlist_id = db.Column(db.String(255), nullable=True)
+    playlist_name = db.Column(db.String(255), nullable=True)
     metadata_json = db.Column(db.JSON, nullable=True)
     created_at = db.Column(
         db.DateTime,
@@ -906,19 +760,11 @@ class ActivityLog(db.Model):
             "playlist_id": self.playlist_id,
             "playlist_name": self.playlist_name,
             "metadata": self.metadata_json,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
         }
 
     def __repr__(self) -> str:
-        return (
-            f"<ActivityLog {self.id}: "
-            f"{self.activity_type} "
-            f"by user {self.user_id}>"
-        )
+        return f"<ActivityLog {self.id}: {self.activity_type} by user {self.user_id}>"
 
 
 class PlaylistPair(db.Model):
@@ -931,30 +777,18 @@ class PlaylistPair(db.Model):
 
     __tablename__ = "playlist_pairs"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
         index=True,
     )
-    production_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    production_playlist_name = db.Column(
-        db.String(255), nullable=True
-    )
-    archive_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    archive_playlist_name = db.Column(
-        db.String(255), nullable=True
-    )
-    auto_archive_on_remove = db.Column(
-        db.Boolean, nullable=False, default=True
-    )
+    production_playlist_id = db.Column(db.String(255), nullable=False)
+    production_playlist_name = db.Column(db.String(255), nullable=True)
+    archive_playlist_id = db.Column(db.String(255), nullable=False)
+    archive_playlist_name = db.Column(db.String(255), nullable=True)
+    auto_archive_on_remove = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -968,9 +802,7 @@ class PlaylistPair(db.Model):
     )
 
     # Relationships
-    user = db.relationship(
-        "User", back_populates="playlist_pairs"
-    )
+    user = db.relationship("User", back_populates="playlist_pairs")
 
     # Unique constraint: one pair per user per production playlist
     __table_args__ = (
@@ -986,29 +818,13 @@ class PlaylistPair(db.Model):
         return {
             "id": self.id,
             "user_id": self.user_id,
-            "production_playlist_id": (
-                self.production_playlist_id
-            ),
-            "production_playlist_name": (
-                self.production_playlist_name
-            ),
+            "production_playlist_id": (self.production_playlist_id),
+            "production_playlist_name": (self.production_playlist_name),
             "archive_playlist_id": self.archive_playlist_id,
-            "archive_playlist_name": (
-                self.archive_playlist_name
-            ),
-            "auto_archive_on_remove": (
-                self.auto_archive_on_remove
-            ),
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "archive_playlist_name": (self.archive_playlist_name),
+            "auto_archive_on_remove": (self.auto_archive_on_remove),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     def __repr__(self) -> str:
@@ -1030,33 +846,19 @@ class RaidPlaylistLink(db.Model):
 
     __tablename__ = "raid_playlist_links"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
         index=True,
     )
-    target_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    target_playlist_name = db.Column(
-        db.String(255), nullable=True
-    )
-    raid_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    raid_playlist_name = db.Column(
-        db.String(255), nullable=True
-    )
-    drip_count = db.Column(
-        db.Integer, nullable=False, default=3
-    )
-    drip_enabled = db.Column(
-        db.Boolean, nullable=False, default=False
-    )
+    target_playlist_id = db.Column(db.String(255), nullable=False)
+    target_playlist_name = db.Column(db.String(255), nullable=True)
+    raid_playlist_id = db.Column(db.String(255), nullable=False)
+    raid_playlist_name = db.Column(db.String(255), nullable=True)
+    drip_count = db.Column(db.Integer, nullable=False, default=3)
+    drip_enabled = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -1070,9 +872,7 @@ class RaidPlaylistLink(db.Model):
     )
 
     # Relationships
-    user = db.relationship(
-        "User", back_populates="raid_playlist_links"
-    )
+    user = db.relationship("User", back_populates="raid_playlist_links")
 
     __table_args__ = (
         db.UniqueConstraint(
@@ -1091,28 +891,14 @@ class RaidPlaylistLink(db.Model):
         return {
             "id": self.id,
             "user_id": self.user_id,
-            "target_playlist_id": (
-                self.target_playlist_id
-            ),
-            "target_playlist_name": (
-                self.target_playlist_name
-            ),
+            "target_playlist_id": (self.target_playlist_id),
+            "target_playlist_name": (self.target_playlist_name),
             "raid_playlist_id": self.raid_playlist_id,
-            "raid_playlist_name": (
-                self.raid_playlist_name
-            ),
+            "raid_playlist_name": (self.raid_playlist_name),
             "drip_count": self.drip_count,
             "drip_enabled": self.drip_enabled,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     def __repr__(self) -> str:
@@ -1134,27 +920,17 @@ class PlaylistPreference(db.Model):
 
     __tablename__ = "playlist_preferences"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
         index=True,
     )
-    spotify_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    sort_order = db.Column(
-        db.Integer, nullable=False, default=0
-    )
-    is_hidden = db.Column(
-        db.Boolean, nullable=False, default=False
-    )
-    is_pinned = db.Column(
-        db.Boolean, nullable=False, default=False
-    )
+    spotify_playlist_id = db.Column(db.String(255), nullable=False)
+    sort_order = db.Column(db.Integer, nullable=False, default=0)
+    is_hidden = db.Column(db.Boolean, nullable=False, default=False)
+    is_pinned = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -1193,16 +969,8 @@ class PlaylistPreference(db.Model):
             "sort_order": self.sort_order,
             "is_hidden": self.is_hidden,
             "is_pinned": self.is_pinned,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "updated_at": (
-                self.updated_at.isoformat()
-                if self.updated_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
     def __repr__(self) -> str:
@@ -1232,24 +1000,16 @@ class TrackLock(db.Model):
 
     STANDARD_EXPIRY_DAYS = 30
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
         index=True,
     )
-    spotify_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    track_uri = db.Column(
-        db.String(255), nullable=False
-    )
-    position = db.Column(
-        db.Integer, nullable=False
-    )
+    spotify_playlist_id = db.Column(db.String(255), nullable=False)
+    track_uri = db.Column(db.String(255), nullable=False)
+    position = db.Column(db.Integer, nullable=False)
     lock_tier = db.Column(
         db.String(20),
         nullable=False,
@@ -1260,9 +1020,7 @@ class TrackLock(db.Model):
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    expires_at = db.Column(
-        db.DateTime, nullable=True
-    )
+    expires_at = db.Column(db.DateTime, nullable=True)
 
     user = db.relationship(
         "User",
@@ -1313,16 +1071,8 @@ class TrackLock(db.Model):
             "track_uri": self.track_uri,
             "position": self.position,
             "lock_tier": self.lock_tier,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "expires_at": (
-                self.expires_at.isoformat()
-                if self.expires_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "expires_at": (self.expires_at.isoformat() if self.expires_at else None),
         }
 
     def __repr__(self) -> str:
@@ -1346,41 +1096,21 @@ class PendingRaidTrack(db.Model):
 
     __tablename__ = "pending_raid_tracks"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id"),
         nullable=False,
     )
-    target_playlist_id = db.Column(
-        db.String(255), nullable=False
-    )
-    track_uri = db.Column(
-        db.String(255), nullable=False
-    )
-    track_name = db.Column(
-        db.String(500), nullable=False
-    )
-    track_artists = db.Column(
-        db.String(1000), nullable=True
-    )
-    track_album = db.Column(
-        db.String(500), nullable=True
-    )
-    track_image_url = db.Column(
-        db.String(1024), nullable=True
-    )
-    track_duration_ms = db.Column(
-        db.Integer, nullable=True
-    )
-    source_playlist_id = db.Column(
-        db.String(255), nullable=True
-    )
-    source_name = db.Column(
-        db.String(255), nullable=True
-    )
+    target_playlist_id = db.Column(db.String(255), nullable=False)
+    track_uri = db.Column(db.String(255), nullable=False)
+    track_name = db.Column(db.String(500), nullable=False)
+    track_artists = db.Column(db.String(1000), nullable=True)
+    track_album = db.Column(db.String(500), nullable=True)
+    track_image_url = db.Column(db.String(1024), nullable=True)
+    track_duration_ms = db.Column(db.Integer, nullable=True)
+    source_playlist_id = db.Column(db.String(255), nullable=True)
+    source_name = db.Column(db.String(255), nullable=True)
     status = db.Column(
         db.String(20),
         nullable=False,
@@ -1391,9 +1121,7 @@ class PendingRaidTrack(db.Model):
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    resolved_at = db.Column(
-        db.DateTime, nullable=True
-    )
+    resolved_at = db.Column(db.DateTime, nullable=True)
 
     # Relationships
     user = db.relationship(
@@ -1419,8 +1147,7 @@ class PendingRaidTrack(db.Model):
             "status",
         ),
         db.CheckConstraint(
-            "status IN ('pending', 'promoted', "
-            "'dismissed')",
+            "status IN ('pending', 'promoted', 'dismissed')",
             name="ck_pending_raid_status",
         ),
     )
@@ -1440,24 +1167,12 @@ class PendingRaidTrack(db.Model):
             "source_playlist_id": self.source_playlist_id,
             "source_name": self.source_name,
             "status": self.status,
-            "created_at": (
-                self.created_at.isoformat()
-                if self.created_at
-                else None
-            ),
-            "resolved_at": (
-                self.resolved_at.isoformat()
-                if self.resolved_at
-                else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
+            "resolved_at": (self.resolved_at.isoformat() if self.resolved_at else None),
         }
 
     def __repr__(self) -> str:
-        return (
-            f"<PendingRaidTrack {self.id}: "
-            f"'{self.track_name}' "
-            f"status={self.status}>"
-        )
+        return f"<PendingRaidTrack {self.id}: '{self.track_name}' status={self.status}>"
 
 
 # =============================================================================
@@ -1477,27 +1192,16 @@ class ScrapedPlaylistCache(db.Model):
 
     __tablename__ = "scraped_playlist_cache"
 
-    id = db.Column(
-        db.Integer, primary_key=True, autoincrement=True
-    )
-    playlist_id = db.Column(
-        db.String(255), nullable=False, index=True
-    )
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    playlist_id = db.Column(db.String(255), nullable=False, index=True)
     track_uris_json = db.Column(db.Text, nullable=False)
-    track_count = db.Column(
-        db.Integer, nullable=False, default=0
-    )
     scraped_at = db.Column(
         db.DateTime,
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    scrape_pathway = db.Column(
-        db.String(50), nullable=True
-    )
-    expires_at = db.Column(
-        db.DateTime, nullable=False
-    )
+    scrape_pathway = db.Column(db.String(50), nullable=True)
+    expires_at = db.Column(db.DateTime, nullable=False)
 
     __table_args__ = (
         db.Index(
@@ -1520,8 +1224,7 @@ class ScrapedPlaylistCache(db.Model):
             return json.loads(self.track_uris_json)
         except (json.JSONDecodeError, TypeError):
             logger.warning(
-                "Failed to decode track_uris_json for "
-                "ScrapedPlaylistCache %s",
+                "Failed to decode track_uris_json for ScrapedPlaylistCache %s",
                 self.id,
             )
             return []
@@ -1532,8 +1235,4 @@ class ScrapedPlaylistCache(db.Model):
         self.track_uris_json = json.dumps(uris)
 
     def __repr__(self) -> str:
-        return (
-            f"<ScrapedPlaylistCache "
-            f"playlist={self.playlist_id} "
-            f"tracks={self.track_count}>"
-        )
+        return f"<ScrapedPlaylistCache playlist={self.playlist_id}>"

--- a/shuffify/routes/core.py
+++ b/shuffify/routes/core.py
@@ -350,7 +350,7 @@ def logout():
     except Exception:
         pass
 
-    # Record logout event before clearing session
+    # Record logout event and activity before clearing session
     try:
         user_data = session.get("user_data")
         if user_data and user_data.get("id"):
@@ -361,23 +361,13 @@ def logout():
                     user_id=db_user.id,
                     session_id=flask_session_id,
                 )
-    except Exception as e:
-        logger.warning(f"Failed to record logout: {e}. Logout continues.")
-
-    # Log logout activity (non-blocking)
-    try:
-        user_data = session.get("user_data", {})
-        spotify_id = user_data.get("id")
-        if spotify_id:
-            db_user = UserService.get_by_spotify_id(spotify_id)
-            if db_user:
                 log_activity(
                     user_id=db_user.id,
                     activity_type=ActivityType.LOGOUT,
                     description="Logged out",
                 )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"Failed to record logout: {e}")
 
     session.clear()
     return redirect(url_for("main.index"))

--- a/shuffify/services/executors/base_executor.py
+++ b/shuffify/services/executors/base_executor.py
@@ -29,6 +29,11 @@ from shuffify.spotify.exceptions import (
 from shuffify.shuffle_algorithms.utils import extract_uris
 from shuffify.enums import JobType, ActivityType
 
+# Sentinel token used when constructing a SpotifyAPI with only a
+# refresh token. The access_token is intentionally invalid so the
+# client triggers an auto-refresh on the first API call.
+_EXPIRED_ACCESS_TOKEN = "expired_placeholder"
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,9 +56,7 @@ def _tag_sentry_scope(schedule, schedule_id):
         scope.set_tag("schedule_id", schedule_id)
         if schedule is not None:
             scope.set_tag("job_type", str(schedule.job_type))
-            scope.set_tag(
-                "playlist_id", schedule.target_playlist_id
-            )
+            scope.set_tag("playlist_id", schedule.target_playlist_id)
             scope.set_user({"id": str(schedule.user_id)})
     except Exception:
         # Never let observability tagging break job execution.
@@ -131,7 +134,8 @@ def verify_playlist_state(
             from expected.
     """
     verified = api.get_playlist_tracks(
-        playlist_id, skip_cache=True,
+        playlist_id,
+        skip_cache=True,
     )
     actual_uris = extract_uris(verified or [])
 
@@ -168,32 +172,124 @@ def _rollback_metadata(error, schedule, restored) -> dict:
         "triggered_by": "scheduler",
     }
     if isinstance(error, PlaylistVerificationError):
-        base.update({
-            "failure_type": "verification",
-            "phase": error.phase,
-            "failing_playlist_id": error.playlist_id,
-            "expected_count": len(error.expected),
-            "actual_count": len(error.actual),
-            "missing_total": len(error.missing),
-            "extra_total": len(error.extra),
-            "missing_uris": error.missing[:50],
-            "extra_uris": error.extra[:50],
-        })
+        base.update(
+            {
+                "failure_type": "verification",
+                "phase": error.phase,
+                "failing_playlist_id": error.playlist_id,
+                "expected_count": len(error.expected),
+                "actual_count": len(error.actual),
+                "missing_total": len(error.missing),
+                "extra_total": len(error.extra),
+                "missing_uris": error.missing[:50],
+                "extra_uris": error.extra[:50],
+            }
+        )
     elif isinstance(error, SpotifyPartialBatchError):
-        base.update({
-            "failure_type": "partial_batch",
-            "method": error.method,
-            "failing_playlist_id": error.playlist_id,
-            "completed_batches": error.completed_batches,
-            "total_batches": error.total_batches,
-            "completed_count": len(error.completed_uris),
-            "remaining_count": len(error.remaining_uris),
-            "remaining_uris": error.remaining_uris[:50],
-            "cause": (
-                str(error.cause) if error.cause else None
-            ),
-        })
+        base.update(
+            {
+                "failure_type": "partial_batch",
+                "method": error.method,
+                "failing_playlist_id": error.playlist_id,
+                "completed_batches": error.completed_batches,
+                "total_batches": error.total_batches,
+                "completed_count": len(error.completed_uris),
+                "remaining_count": len(error.remaining_uris),
+                "remaining_uris": error.remaining_uris[:50],
+                "cause": (str(error.cause) if error.cause else None),
+            }
+        )
     return base
+
+
+def _restore_job_snapshots(execution, schedule, api, schedule_id):
+    """Restore auto-snapshots taken during this job.
+
+    Returns a list of restoration dicts on success, or None if
+    restoration fails (caller should fall back to plain failure).
+    """
+    from shuffify.services.playlist_snapshot_service import (  # noqa: E501
+        PlaylistSnapshotService,
+        PlaylistSnapshotError,
+    )
+    from shuffify.models.db import PlaylistSnapshot
+
+    try:
+        user_id = schedule.user_id if schedule else None
+        since = execution.started_at if execution else None
+        if not user_id or not since:
+            raise PlaylistSnapshotError(
+                "Missing user_id or job start time; cannot scope snapshots."
+            )
+
+        pre_snapshots = (
+            PlaylistSnapshot.query.filter(
+                PlaylistSnapshot.user_id == user_id,
+                PlaylistSnapshot.created_at >= since,
+            )
+            .order_by(PlaylistSnapshot.created_at.asc())
+            .all()
+        )
+
+        if not pre_snapshots:
+            raise PlaylistSnapshotError(
+                "No pre-snapshot available for rollback "
+                "(auto-snapshots disabled or empty "
+                "source playlists)."
+            )
+
+        # One snapshot per playlist — keep the most recent.
+        latest_by_playlist = {}
+        for snap in pre_snapshots:
+            latest_by_playlist[snap.playlist_id] = snap
+
+        restored = []
+        for playlist_id, snap in latest_by_playlist.items():
+            applied = PlaylistSnapshotService.restore_to_playlist(
+                snap.id,
+                user_id,
+                api,
+            )
+            restored.append(
+                {
+                    "playlist_id": playlist_id,
+                    "snapshot_id": snap.id,
+                    "track_count": applied.track_count,
+                }
+            )
+        return restored
+
+    except Exception as restore_err:
+        logger.error(
+            "Schedule %s: rollback failed: %s. Falling back to plain failure.",
+            schedule_id,
+            restore_err,
+            exc_info=True,
+        )
+        return None
+
+
+def _persist_rollback_status(execution, schedule, ve, schedule_id):
+    """Write failed_rolled_back status to db."""
+    try:
+        if execution:
+            execution.status = "failed_rolled_back"
+            execution.completed_at = datetime.now(timezone.utc)
+            execution.error_message = str(ve)[:1000]
+
+        if schedule:
+            schedule.last_run_at = datetime.now(timezone.utc)
+            schedule.last_status = "failed_rolled_back"
+            schedule.last_error = str(ve)[:1000]
+
+        db.session.commit()
+    except Exception as db_err:
+        logger.error(
+            "Schedule %s: failed to persist rollback status: %s",
+            schedule_id,
+            db_err,
+        )
+        db.session.rollback()
 
 
 class JobExecutorService:
@@ -213,54 +309,40 @@ class JobExecutorService:
         try:
             schedule = db.session.get(Schedule, schedule_id)
             if not schedule:
-                logger.error(
-                    f"Schedule {schedule_id} not found, "
-                    f"skipping"
-                )
+                logger.error(f"Schedule {schedule_id} not found, skipping")
                 return
 
             if not schedule.is_enabled:
-                logger.info(
-                    f"Schedule {schedule_id} is disabled, "
-                    f"skipping"
-                )
+                logger.info(f"Schedule {schedule_id} is disabled, skipping")
                 return
 
             _tag_sentry_scope(schedule, schedule_id)
 
-            execution = (
-                JobExecutorService._create_execution_record(
-                    schedule_id
-                )
-            )
+            execution = JobExecutorService._create_execution_record(schedule_id)
 
             user = db.session.get(User, schedule.user_id)
             if not user:
-                raise JobExecutionError(
-                    f"User {schedule.user_id} not found"
-                )
+                raise JobExecutionError(f"User {schedule.user_id} not found")
 
             api = JobExecutorService._get_spotify_api(user)
 
-            result = JobExecutorService._execute_job_type(
-                schedule, api
-            )
+            result = JobExecutorService._execute_job_type(schedule, api)
 
-            JobExecutorService._record_success(
-                execution, schedule, result
-            )
+            JobExecutorService._record_success(execution, schedule, result)
 
         except (
             PlaylistVerificationError,
             SpotifyPartialBatchError,
         ) as ve:
             JobExecutorService._record_rollback(
-                execution, schedule, api, ve, schedule_id,
+                execution,
+                schedule,
+                api,
+                ve,
+                schedule_id,
             )
         except Exception as e:
-            JobExecutorService._record_failure(
-                execution, schedule, e, schedule_id
-            )
+            JobExecutorService._record_failure(execution, schedule, e, schedule_id)
 
     @staticmethod
     def _create_execution_record(
@@ -288,12 +370,8 @@ class JobExecutorService:
         """Record a successful job execution."""
         execution.status = "success"
         execution.completed_at = datetime.now(timezone.utc)
-        execution.tracks_added = result.get(
-            "tracks_added", 0
-        )
-        execution.tracks_total = result.get(
-            "tracks_total", 0
-        )
+        execution.tracks_added = result.get("tracks_added", 0)
+        execution.tracks_total = result.get("tracks_total", 0)
 
         schedule.last_run_at = datetime.now(timezone.utc)
         schedule.last_status = "success"
@@ -309,30 +387,20 @@ class JobExecutorService:
 
             ActivityLogService.log(
                 user_id=schedule.user_id,
-                activity_type=(
-                    ActivityType.SCHEDULE_RUN
-                ),
+                activity_type=(ActivityType.SCHEDULE_RUN),
                 description=(
                     f"Scheduled "
                     f"{schedule.job_type} on "
                     f"'{schedule.target_playlist_name}'"
                     f" completed"
                 ),
-                playlist_id=(
-                    schedule.target_playlist_id
-                ),
-                playlist_name=(
-                    schedule.target_playlist_name
-                ),
+                playlist_id=(schedule.target_playlist_id),
+                playlist_name=(schedule.target_playlist_name),
                 metadata={
                     "schedule_id": schedule.id,
                     "job_type": schedule.job_type,
-                    "tracks_added": result.get(
-                        "tracks_added", 0
-                    ),
-                    "tracks_total": result.get(
-                        "tracks_total", 0
-                    ),
+                    "tracks_added": result.get("tracks_added", 0),
+                    "tracks_total": result.get("tracks_total", 0),
                     "triggered_by": "scheduler",
                 },
             )
@@ -355,31 +423,23 @@ class JobExecutorService:
     ) -> None:
         """Record a failed job execution."""
         logger.error(
-            f"Schedule {schedule_id} execution "
-            f"failed: {error}",
+            f"Schedule {schedule_id} execution failed: {error}",
             exc_info=True,
         )
         try:
             if execution:
                 execution.status = "failed"
-                execution.completed_at = datetime.now(
-                    timezone.utc
-                )
+                execution.completed_at = datetime.now(timezone.utc)
                 execution.error_message = str(error)[:1000]
 
             if schedule:
-                schedule.last_run_at = datetime.now(
-                    timezone.utc
-                )
+                schedule.last_run_at = datetime.now(timezone.utc)
                 schedule.last_status = "failed"
                 schedule.last_error = str(error)[:1000]
 
             db.session.commit()
         except Exception as db_err:
-            logger.error(
-                f"Failed to record execution failure: "
-                f"{db_err}"
-            )
+            logger.error(f"Failed to record execution failure: {db_err}")
             db.session.rollback()
 
     @staticmethod
@@ -403,19 +463,17 @@ class JobExecutorService:
         missing), falls through to `_record_failure` so the
         execution is still recorded as failed.
         """
-        from shuffify.services.playlist_snapshot_service import (  # noqa: E501
-            PlaylistSnapshotService,
-            PlaylistSnapshotError,
-        )
-        from shuffify.models.db import PlaylistSnapshot
 
         if isinstance(ve, PlaylistVerificationError):
             logger.error(
                 "Schedule %s: verification failed in phase "
                 "'%s' on playlist %s — attempting snapshot "
                 "rollback. Missing=%d, extra=%d.",
-                schedule_id, ve.phase, ve.playlist_id,
-                len(ve.missing), len(ve.extra),
+                schedule_id,
+                ve.phase,
+                ve.playlist_id,
+                len(ve.missing),
+                len(ve.extra),
             )
         else:
             logger.error(
@@ -423,108 +481,37 @@ class JobExecutorService:
                 "%s (batch %d/%d) — attempting snapshot "
                 "rollback. Completed=%d, remaining=%d. "
                 "Cause: %s",
-                schedule_id, ve.method, ve.playlist_id,
-                ve.completed_batches, ve.total_batches,
+                schedule_id,
+                ve.method,
+                ve.playlist_id,
+                ve.completed_batches,
+                ve.total_batches,
                 len(ve.completed_uris),
-                len(ve.remaining_uris), ve.cause,
+                len(ve.remaining_uris),
+                ve.cause,
             )
 
-        restored = []
-        try:
-            user_id = (
-                schedule.user_id if schedule else None
-            )
-            since = (
-                execution.started_at if execution else None
-            )
-            if not user_id or not since:
-                raise PlaylistSnapshotError(
-                    "Missing user_id or job start time; "
-                    "cannot scope snapshots."
-                )
-
-            # All auto-snapshots created since the job
-            # started belong to this run.
-            pre_snapshots = (
-                PlaylistSnapshot.query
-                .filter(
-                    PlaylistSnapshot.user_id == user_id,
-                    PlaylistSnapshot.created_at >= since,
-                )
-                .order_by(
-                    PlaylistSnapshot.created_at.asc()
-                )
-                .all()
-            )
-
-            if not pre_snapshots:
-                raise PlaylistSnapshotError(
-                    "No pre-snapshot available for "
-                    "rollback (auto-snapshots disabled "
-                    "or empty source playlists)."
-                )
-
-            # One snapshot per playlist — restore the most
-            # recent if multiple were taken.
-            latest_by_playlist = {}
-            for snap in pre_snapshots:
-                latest_by_playlist[snap.playlist_id] = snap
-
-            for playlist_id, snap in (
-                latest_by_playlist.items()
-            ):
-                applied = (
-                    PlaylistSnapshotService
-                    .restore_to_playlist(
-                        snap.id, user_id, api,
-                    )
-                )
-                restored.append(
-                    {
-                        "playlist_id": playlist_id,
-                        "snapshot_id": snap.id,
-                        "track_count": (
-                            applied.track_count
-                        ),
-                    }
-                )
-        except Exception as restore_err:
-            logger.error(
-                "Schedule %s: rollback failed: %s. "
-                "Falling back to plain failure.",
-                schedule_id, restore_err, exc_info=True,
-            )
+        restored = _restore_job_snapshots(
+            execution,
+            schedule,
+            api,
+            schedule_id,
+        )
+        if restored is None:
             JobExecutorService._record_failure(
-                execution, schedule, ve, schedule_id,
+                execution,
+                schedule,
+                ve,
+                schedule_id,
             )
             return
 
-        # Persist the rolled-back status
-        try:
-            if execution:
-                execution.status = "failed_rolled_back"
-                execution.completed_at = datetime.now(
-                    timezone.utc
-                )
-                execution.error_message = str(ve)[:1000]
-
-            if schedule:
-                schedule.last_run_at = datetime.now(
-                    timezone.utc
-                )
-                schedule.last_status = (
-                    "failed_rolled_back"
-                )
-                schedule.last_error = str(ve)[:1000]
-
-            db.session.commit()
-        except Exception as db_err:
-            logger.error(
-                "Schedule %s: failed to persist "
-                "rollback status: %s",
-                schedule_id, db_err,
-            )
-            db.session.rollback()
+        _persist_rollback_status(
+            execution,
+            schedule,
+            ve,
+            schedule_id,
+        )
 
         # Log a structured activity entry (non-blocking).
         try:
@@ -534,9 +521,7 @@ class JobExecutorService:
 
             ActivityLogService.log(
                 user_id=schedule.user_id,
-                activity_type=(
-                    ActivityType.SCHEDULE_RUN_ROLLED_BACK
-                ),
+                activity_type=(ActivityType.SCHEDULE_RUN_ROLLED_BACK),
                 description=(
                     "Scheduled "
                     f"{schedule.job_type} on "
@@ -545,20 +530,18 @@ class JobExecutorService:
                     f"{_rollback_trigger_phrase(ve)}"
                 ),
                 playlist_id=schedule.target_playlist_id,
-                playlist_name=(
-                    schedule.target_playlist_name
-                ),
+                playlist_name=(schedule.target_playlist_name),
                 metadata=_rollback_metadata(
-                    ve, schedule, restored,
+                    ve,
+                    schedule,
+                    restored,
                 ),
             )
         except Exception:
             pass
 
     @staticmethod
-    def execute_now(
-        schedule_id: int, user_id: int
-    ) -> dict:
+    def execute_now(schedule_id: int, user_id: int) -> dict:
         """
         Manually trigger a schedule execution (from the UI).
 
@@ -571,13 +554,9 @@ class JobExecutorService:
         )
 
         try:
-            schedule = SchedulerService.get_schedule(
-                schedule_id, user_id
-            )
+            schedule = SchedulerService.get_schedule(schedule_id, user_id)
         except ScheduleNotFoundError:
-            raise JobExecutionError(
-                f"Schedule {schedule_id} not found"
-            )
+            raise JobExecutionError(f"Schedule {schedule_id} not found")
 
         # Execute synchronously
         JobExecutorService.execute(schedule_id)
@@ -587,17 +566,14 @@ class JobExecutorService:
         db.session.refresh(schedule)
 
         if schedule.last_status in (
-            "failed", "failed_rolled_back",
+            "failed",
+            "failed_rolled_back",
         ):
-            raise JobExecutionError(
-                schedule.last_error or "Unknown error"
-            )
+            raise JobExecutionError(schedule.last_error or "Unknown error")
 
         # Return detailed result from latest execution
         latest = (
-            JobExecution.query.filter_by(
-                schedule_id=schedule_id
-            )
+            JobExecution.query.filter_by(schedule_id=schedule_id)
             .order_by(JobExecution.started_at.desc())
             .first()
         )
@@ -605,19 +581,13 @@ class JobExecutorService:
         result = {
             "status": schedule.last_status or "unknown",
             "last_run_at": (
-                schedule.last_run_at.isoformat()
-                if schedule.last_run_at
-                else None
+                schedule.last_run_at.isoformat() if schedule.last_run_at else None
             ),
         }
 
         if latest:
-            result["tracks_total"] = (
-                latest.tracks_total or 0
-            )
-            result["tracks_added"] = (
-                latest.tracks_added or 0
-            )
+            result["tracks_total"] = latest.tracks_total or 0
+            result["tracks_added"] = latest.tracks_added or 0
             if latest.error_message:
                 result["error"] = latest.error_message
 
@@ -641,28 +611,23 @@ class JobExecutorService:
             )
 
         try:
-            refresh_token = TokenService.decrypt_token(
-                user.encrypted_refresh_token
-            )
+            refresh_token = TokenService.decrypt_token(user.encrypted_refresh_token)
         except TokenEncryptionError as e:
             raise JobExecutionError(
-                f"Failed to decrypt refresh token for user "
-                f"{user.spotify_id}: {e}"
+                f"Failed to decrypt refresh token for user {user.spotify_id}: {e}"
             )
 
         try:
             from flask import current_app
 
-            credentials = SpotifyCredentials.from_flask_config(
-                current_app.config
-            )
+            credentials = SpotifyCredentials.from_flask_config(current_app.config)
             auth_manager = SpotifyAuthManager(credentials)
 
             # Create a token_info with an expired access token
             # and valid refresh token. SpotifyAPI will
             # auto-refresh on first call.
             token_info = TokenInfo(
-                access_token="expired_placeholder",
+                access_token=_EXPIRED_ACCESS_TOKEN,
                 token_type="Bearer",
                 expires_at=0,
                 refresh_token=refresh_token,
@@ -676,33 +641,22 @@ class JobExecutorService:
 
             # Update stored refresh token if it was rotated
             new_token = api.token_info
-            if (
-                new_token.refresh_token
-                and new_token.refresh_token != refresh_token
-            ):
-                user.encrypted_refresh_token = (
-                    TokenService.encrypt_token(
-                        new_token.refresh_token
-                    )
+            if new_token.refresh_token and new_token.refresh_token != refresh_token:
+                user.encrypted_refresh_token = TokenService.encrypt_token(
+                    new_token.refresh_token
                 )
                 db.session.commit()
-                logger.info(
-                    f"Updated rotated refresh token for "
-                    f"user {user.spotify_id}"
-                )
+                logger.info(f"Updated rotated refresh token for user {user.spotify_id}")
 
             return api
 
         except SpotifyTokenError as e:
             raise JobExecutionError(
-                f"Failed to refresh Spotify token for user "
-                f"{user.spotify_id}: {e}"
+                f"Failed to refresh Spotify token for user {user.spotify_id}: {e}"
             )
 
     @staticmethod
-    def _execute_job_type(
-        schedule: Schedule, api: SpotifyAPI
-    ) -> dict:
+    def _execute_job_type(schedule: Schedule, api: SpotifyAPI) -> dict:
         """Execute the appropriate operation based on job type."""
         from shuffify.services.executors.raid_executor import (
             execute_raid,
@@ -724,32 +678,16 @@ class JobExecutorService:
         elif schedule.job_type == JobType.RAID_AND_SHUFFLE:
             result = execute_raid(schedule, api)
             shuffle_result = execute_shuffle(schedule, api)
-            result["tracks_total"] = shuffle_result[
-                "tracks_total"
-            ]
+            result["tracks_total"] = shuffle_result["tracks_total"]
             return result
         elif schedule.job_type == JobType.RAID_AND_DRIP:
             result = execute_raid(schedule, api)
             drip_result = execute_drip(schedule, api)
-            result["tracks_dripped"] = drip_result.get(
-                "tracks_added", 0
-            )
+            result["tracks_dripped"] = drip_result.get("tracks_added", 0)
             return result
         elif schedule.job_type == JobType.ROTATE:
             return execute_rotate(schedule, api)
         elif schedule.job_type == JobType.DRIP:
             return execute_drip(schedule, api)
         else:
-            raise JobExecutionError(
-                f"Unknown job type: {schedule.job_type}"
-            )
-
-    @staticmethod
-    def _batch_add_tracks(
-        api: SpotifyAPI,
-        playlist_id: str,
-        uris: List[str],
-        batch_size: int = 100,
-    ) -> None:
-        """Add tracks to a playlist in batches."""
-        api.playlist_add_items(playlist_id, uris)
+            raise JobExecutionError(f"Unknown job type: {schedule.job_type}")

--- a/shuffify/services/executors/rotate_executor.py
+++ b/shuffify/services/executors/rotate_executor.py
@@ -1,9 +1,6 @@
 """
 Rotate executor: swap rotation and pairing logic for
 production/archive playlist management.
-
-Currently only supports swap mode. See git history for
-prior archive_oldest and refresh implementations.
 """
 
 import logging
@@ -19,7 +16,6 @@ from shuffify.enums import SnapshotType, RotationMode
 from shuffify.shuffle_algorithms.utils import extract_uris
 from shuffify.services.executors.base_executor import (
     JobExecutionError,
-    JobExecutorService,
     verify_playlist_state,
 )
 from shuffify.services.playlist_snapshot_service import (
@@ -39,54 +35,48 @@ def _expected_after(prev_uris, removed_uris, added_uris):
     additions are appended in order.
     """
     removed_set = set(removed_uris)
-    return [u for u in prev_uris if u not in removed_set] + list(
-        added_uris
-    )
+    return [u for u in prev_uris if u not in removed_set] + list(added_uris)
 
 
-def execute_rotate(
-    schedule: Schedule, api: SpotifyAPI
-) -> dict:
+def execute_rotate(schedule: Schedule, api: SpotifyAPI) -> dict:
     """
     Rotate tracks between production and archive
     playlists.
     """
     target_id = schedule.target_playlist_id
     (
-        rotation_mode, rotation_count,
-        target_size, protect_count, pair,
+        rotation_mode,
+        rotation_count,
+        target_size,
+        protect_count,
+        pair,
     ) = _validate_rotation_config(schedule)
     archive_id = pair.archive_playlist_id
 
     try:
-        prod_tracks = api.get_playlist_tracks(
-            target_id
-        )
+        prod_tracks = api.get_playlist_tracks(target_id)
         if not prod_tracks:
             return {
                 "tracks_added": 0,
                 "tracks_total": 0,
             }
 
-        prod_uris = [
-            t["uri"]
-            for t in prod_tracks
-            if t.get("uri")
-        ]
+        prod_uris = [t["uri"] for t in prod_tracks if t.get("uri")]
 
-        _auto_snapshot_before_rotate(
-            schedule, prod_uris, rotation_mode
-        )
+        _auto_snapshot_before_rotate(schedule, prod_uris, rotation_mode)
 
         if target_size is None or target_size < 1:
             raise JobExecutionError(
-                "Swap rotation requires a playlist "
-                "size cap (target_size) of at least 1"
+                "Swap rotation requires a playlist size cap (target_size) of at least 1"
             )
         return _rotate_swap(
-            api, schedule, target_id,
-            archive_id, prod_uris,
-            rotation_count, target_size,
+            api,
+            schedule,
+            target_id,
+            archive_id,
+            prod_uris,
+            rotation_count,
+            target_size,
             protect_count,
         )
 
@@ -94,16 +84,12 @@ def execute_rotate(
         raise
     except SpotifyNotFoundError:
         raise JobExecutionError(
-            "Playlist not found during rotation. "
-            "Target: {}, Archive: {}".format(
+            "Playlist not found during rotation. Target: {}, Archive: {}".format(
                 target_id, archive_id
             )
         )
     except SpotifyAPIError as e:
-        raise JobExecutionError(
-            "Spotify API error during "
-            "rotation: {}".format(e)
-        )
+        raise JobExecutionError("Spotify API error during rotation: {}".format(e))
 
 
 def _validate_rotation_config(
@@ -126,44 +112,34 @@ def _validate_rotation_config(
     )
 
     params = schedule.algorithm_params or {}
-    rotation_mode = params.get(
-        "rotation_mode", RotationMode.SWAP
-    )
-    rotation_count = max(
-        1, int(params.get("rotation_count", 5))
-    )
+    rotation_mode = params.get("rotation_mode", RotationMode.SWAP)
+    rotation_count = max(1, int(params.get("rotation_count", 5)))
     target_size = params.get("target_size")
     if target_size is not None:
         target_size = max(1, int(target_size))
-    protect_count = max(
-        0, int(params.get("protect_count", 0))
-    )
+    protect_count = max(0, int(params.get("protect_count", 0)))
 
     valid_modes = set(RotationMode)
     if rotation_mode not in valid_modes:
-        raise JobExecutionError(
-            "Invalid rotation_mode: "
-            "{}".format(rotation_mode)
-        )
+        raise JobExecutionError("Invalid rotation_mode: {}".format(rotation_mode))
 
     pair = PlaylistPairService.get_pair_for_playlist(
         user_id=schedule.user_id,
-        production_playlist_id=(
-            schedule.target_playlist_id
-        ),
+        production_playlist_id=(schedule.target_playlist_id),
     )
     if not pair:
         raise JobExecutionError(
             "No archive pair found for playlist "
             "{}. Create a pair in the workshop "
-            "first.".format(
-                schedule.target_playlist_id
-            )
+            "first.".format(schedule.target_playlist_id)
         )
 
     return (
-        rotation_mode, rotation_count,
-        target_size, protect_count, pair,
+        rotation_mode,
+        rotation_count,
+        target_size,
+        protect_count,
+        pair,
     )
 
 
@@ -175,44 +151,23 @@ def _auto_snapshot_before_rotate(
     """Create an auto-snapshot before rotation if
     enabled."""
     try:
-        if (
-            prod_uris
-            and PlaylistSnapshotService
-            .is_auto_snapshot_enabled(
-                schedule.user_id
-            )
+        if prod_uris and PlaylistSnapshotService.is_auto_snapshot_enabled(
+            schedule.user_id
         ):
             PlaylistSnapshotService.create_snapshot(
                 user_id=schedule.user_id,
-                playlist_id=(
-                    schedule.target_playlist_id
-                ),
+                playlist_id=(schedule.target_playlist_id),
                 playlist_name=(
-                    schedule.target_playlist_name
-                    or schedule.target_playlist_id
+                    schedule.target_playlist_name or schedule.target_playlist_id
                 ),
                 track_uris=prod_uris,
-                snapshot_type=(
-                    SnapshotType.AUTO_PRE_ROTATE
-                ),
+                snapshot_type=(SnapshotType.AUTO_PRE_ROTATE),
                 trigger_description=(
-                    "Before scheduled "
-                    "{} rotation".format(
-                        rotation_mode
-                    )
+                    "Before scheduled {} rotation".format(rotation_mode)
                 ),
             )
     except Exception as snap_err:
-        logger.warning(
-            "Auto-snapshot before rotation "
-            "failed: %s", snap_err
-        )
-
-
-# TODO: Re-implement archive_oldest mode
-# (see git history for prior _rotate_archive)
-# TODO: Re-implement refresh mode
-# (see git history for prior _rotate_refresh)
+        logger.warning("Auto-snapshot before rotation failed: %s", snap_err)
 
 
 def _sample_at_most(pool, count):
@@ -226,7 +181,10 @@ def _sample_at_most(pool, count):
 
 
 def _purge_archive_overlaps(
-    api, archive_id, archive_uris, prod_set,
+    api,
+    archive_id,
+    archive_uris,
+    prod_set,
 ):
     """Remove tracks from archive that already exist
     in the production playlist.
@@ -245,14 +203,16 @@ def _purge_archive_overlaps(
     """
     overlaps, cleaned = [], []
     for u in archive_uris:
-        (overlaps if u in prod_set
-         else cleaned).append(u)
+        (overlaps if u in prod_set else cleaned).append(u)
 
     if overlaps:
         try:
             _checked_remove(
-                api, archive_id, overlaps,
-                None, "archive overlap purge",
+                api,
+                archive_id,
+                overlaps,
+                None,
+                "archive overlap purge",
             )
         except (
             SpotifyAPIError,
@@ -264,41 +224,51 @@ def _purge_archive_overlaps(
                 "tracks from archive {}. Aborting "
                 "rotation to prevent "
                 "duplicates.".format(
-                    len(overlaps), archive_id,
+                    len(overlaps),
+                    archive_id,
                 )
             )
         logger.info(
-            "Purged %d overlapping tracks from "
-            "archive %s",
-            len(overlaps), archive_id,
+            "Purged %d overlapping tracks from archive %s",
+            len(overlaps),
+            archive_id,
         )
     return cleaned, len(overlaps)
 
 
 def _checked_remove(
-    api, playlist_id, uris, schedule_id, phase,
+    api,
+    playlist_id,
+    uris,
+    schedule_id,
+    phase,
 ):
     """Remove tracks and verify the operation succeeded.
 
     Raises JobExecutionError if the Spotify API returns
     a falsy result, indicating a silent failure.
     """
-    result = api.playlist_remove_items(
-        playlist_id, uris
-    )
+    result = api.playlist_remove_items(playlist_id, uris)
     if not result:
         raise JobExecutionError(
             "Schedule {}: {} failed — "
             "playlist_remove_items returned falsy "
             "for playlist {}".format(
-                schedule_id, phase, playlist_id,
+                schedule_id,
+                phase,
+                playlist_id,
             )
         )
 
 
 def _rotate_swap(
-    api, schedule, target_id, archive_id,
-    prod_uris, rotation_count, target_size,
+    api,
+    schedule,
+    target_id,
+    archive_id,
+    prod_uris,
+    rotation_count,
+    target_size,
     protect_count=0,
 ):
     """Exchange tracks between production and archive.
@@ -319,9 +289,7 @@ def _rotate_swap(
     swap rotation_count tracks between production and
     archive.
     """
-    archive_tracks = api.get_playlist_tracks(
-        archive_id
-    )
+    archive_tracks = api.get_playlist_tracks(archive_id)
     archive_uris = extract_uris(archive_tracks or [])
 
     prod_set = set(prod_uris)
@@ -329,7 +297,10 @@ def _rotate_swap(
     # Step 0: Purge archive tracks that overlap with
     # production to keep the archive clean.
     archive_uris, purged = _purge_archive_overlaps(
-        api, archive_id, archive_uris, prod_set,
+        api,
+        archive_id,
+        archive_uris,
+        prod_set,
     )
 
     archive_set = set(archive_uris)
@@ -339,18 +310,14 @@ def _rotate_swap(
     from shuffify.services.track_lock_service import (
         TrackLockService,
     )
-    locked_uris = TrackLockService.safe_get_locked_uris(
-        schedule.user_id, target_id
-    )
+
+    locked_uris = TrackLockService.safe_get_locked_uris(schedule.user_id, target_id)
     if locked_uris:
-        eligible_uris = [
-            u for u in eligible_uris
-            if u not in locked_uris
-        ]
+        eligible_uris = [u for u in eligible_uris if u not in locked_uris]
         logger.info(
-            "Schedule %s: %d tracks locked, "
-            "%d eligible after filtering",
-            schedule.id, len(locked_uris),
+            "Schedule %s: %d tracks locked, %d eligible after filtering",
+            schedule.id,
+            len(locked_uris),
             len(eligible_uris),
         )
 
@@ -361,7 +328,8 @@ def _rotate_swap(
             "Schedule %s: protect_count (%d) + "
             "locks (%d) >= playlist size (%d) "
             "— no tracks eligible for rotation",
-            schedule.id, protect_count,
+            schedule.id,
+            protect_count,
             len(locked_uris),
             len(prod_uris),
         )
@@ -372,138 +340,168 @@ def _rotate_swap(
         }
 
     # Phase 1: Archive overflow to reach target_size
-    if (
-        target_size is not None
-        and len(prod_uris) > target_size
-    ):
-        overflow = len(prod_uris) - target_size
-        overflow_uris = _sample_at_most(
-            eligible_uris, overflow
+    if target_size is not None and len(prod_uris) > target_size:
+        return _overflow_to_archive(
+            api,
+            schedule,
+            target_id,
+            archive_id,
+            prod_uris,
+            archive_uris,
+            archive_set,
+            eligible_uris,
+            target_size,
         )
-
-        # Remove from production FIRST
-        _checked_remove(
-            api, target_id, overflow_uris,
-            schedule.id, "overflow prod-remove",
-        )
-
-        # Then archive (deduped)
-        new_to_archive = [
-            u for u in overflow_uris
-            if u not in archive_set
-        ]
-        if new_to_archive:
-            JobExecutorService._batch_add_tracks(
-                api, archive_id, new_to_archive
-            )
-
-        expected_prod = _expected_after(
-            prod_uris, overflow_uris, [],
-        )
-        verified_prod = verify_playlist_state(
-            api, target_id, expected_prod,
-            schedule.id, "overflow",
-        )
-        actual_total = len(verified_prod)
-
-        expected_archive = _expected_after(
-            archive_uris, [], new_to_archive,
-        )
-        verify_playlist_state(
-            api, archive_id, expected_archive,
-            schedule.id, "overflow archive",
-        )
-
-        logger.info(
-            "Schedule %s: archived %d overflow "
-            "tracks from '%s' (cap %d, "
-            "actual %d)",
-            schedule.id, len(overflow_uris),
-            schedule.target_playlist_name,
-            target_size, actual_total,
-        )
-
-        return {
-            "tracks_added": 0,
-            "tracks_total": actual_total,
-        }
 
     # Phase 2: Normal swap (playlist at or under cap)
-    # Swap-in uses first N from archive (FIFO: oldest
-    # archived tracks rotate back in first).
-    swap_in_uris = archive_uris[:rotation_count]
-
-    # Randomly select swap-out tracks from eligible
-    swap_out_uris = _sample_at_most(
-        eligible_uris, len(swap_in_uris)
+    swapped, actual_total = _execute_swap(
+        api,
+        schedule,
+        target_id,
+        archive_id,
+        prod_uris,
+        archive_uris,
+        archive_set,
+        eligible_uris,
+        rotation_count,
     )
-
-    swapped = min(
-        len(swap_in_uris),
-        len(swap_out_uris),
-    )
-
-    if swap_in_uris and swap_out_uris:
-        # Remove outgoing from production first
-        _checked_remove(
-            api, target_id, swap_out_uris,
-            schedule.id, "swap prod-remove",
-        )
-
-        # Then archive outgoing (deduped)
-        new_to_archive = [
-            u for u in swap_out_uris
-            if u not in archive_set
-        ]
-        if new_to_archive:
-            JobExecutorService._batch_add_tracks(
-                api, archive_id, new_to_archive
-            )
-
-        # Remove incoming from archive first
-        _checked_remove(
-            api, archive_id, swap_in_uris,
-            schedule.id, "swap archive-remove",
-        )
-
-        # Then add incoming to production
-        JobExecutorService._batch_add_tracks(
-            api, target_id, swap_in_uris
-        )
-
-        # Asymmetric swap (locks/protect/depleted pool can
-        # make swap_in and swap_out differ in length) means
-        # we can't verify against the original prod size.
-        expected_prod = _expected_after(
-            prod_uris, swap_out_uris, swap_in_uris,
-        )
-        verified_prod = verify_playlist_state(
-            api, target_id, expected_prod,
-            schedule.id, "swap",
-        )
-        actual_total = len(verified_prod)
-
-        expected_archive = _expected_after(
-            archive_uris, swap_in_uris, new_to_archive,
-        )
-        verify_playlist_state(
-            api, archive_id, expected_archive,
-            schedule.id, "swap archive",
-        )
-    else:
-        # Nothing to swap (archive empty or eligible pool
-        # depleted). No writes happened, so the prod size
-        # is unchanged.
-        actual_total = len(prod_uris)
 
     logger.info(
-        "Schedule %s: swapped %d tracks between "
-        "'%s' and archive (purged %d overlaps)",
-        schedule.id, swapped,
-        schedule.target_playlist_name, purged,
+        "Schedule %s: swapped %d tracks between '%s' and archive (purged %d overlaps)",
+        schedule.id,
+        swapped,
+        schedule.target_playlist_name,
+        purged,
     )
 
     return {
         "tracks_added": swapped,
         "tracks_total": actual_total,
     }
+
+
+def _overflow_to_archive(
+    api,
+    schedule,
+    target_id,
+    archive_id,
+    prod_uris,
+    archive_uris,
+    archive_set,
+    eligible_uris,
+    target_size,
+):
+    """Phase 1: move excess tracks from production to archive."""
+    overflow = len(prod_uris) - target_size
+    overflow_uris = _sample_at_most(eligible_uris, overflow)
+
+    _checked_remove(
+        api,
+        target_id,
+        overflow_uris,
+        schedule.id,
+        "overflow prod-remove",
+    )
+
+    new_to_archive = [u for u in overflow_uris if u not in archive_set]
+    if new_to_archive:
+        api.playlist_add_items(archive_id, new_to_archive)
+
+    expected_prod = _expected_after(prod_uris, overflow_uris, [])
+    verified_prod = verify_playlist_state(
+        api,
+        target_id,
+        expected_prod,
+        schedule.id,
+        "overflow",
+    )
+    actual_total = len(verified_prod)
+
+    expected_archive = _expected_after(archive_uris, [], new_to_archive)
+    verify_playlist_state(
+        api,
+        archive_id,
+        expected_archive,
+        schedule.id,
+        "overflow archive",
+    )
+
+    logger.info(
+        "Schedule %s: archived %d overflow tracks from '%s' (cap %d, actual %d)",
+        schedule.id,
+        len(overflow_uris),
+        schedule.target_playlist_name,
+        target_size,
+        actual_total,
+    )
+
+    return {
+        "tracks_added": 0,
+        "tracks_total": actual_total,
+    }
+
+
+def _execute_swap(
+    api,
+    schedule,
+    target_id,
+    archive_id,
+    prod_uris,
+    archive_uris,
+    archive_set,
+    eligible_uris,
+    rotation_count,
+):
+    """Phase 2: swap tracks between production and archive.
+
+    Returns (swapped_count, actual_total).
+    """
+    swap_in_uris = archive_uris[:rotation_count]
+    swap_out_uris = _sample_at_most(eligible_uris, len(swap_in_uris))
+
+    swapped = min(len(swap_in_uris), len(swap_out_uris))
+
+    if not (swap_in_uris and swap_out_uris):
+        return 0, len(prod_uris)
+
+    _checked_remove(
+        api,
+        target_id,
+        swap_out_uris,
+        schedule.id,
+        "swap prod-remove",
+    )
+
+    new_to_archive = [u for u in swap_out_uris if u not in archive_set]
+    if new_to_archive:
+        api.playlist_add_items(archive_id, new_to_archive)
+
+    _checked_remove(
+        api,
+        archive_id,
+        swap_in_uris,
+        schedule.id,
+        "swap archive-remove",
+    )
+
+    api.playlist_add_items(target_id, swap_in_uris)
+
+    expected_prod = _expected_after(prod_uris, swap_out_uris, swap_in_uris)
+    verified_prod = verify_playlist_state(
+        api,
+        target_id,
+        expected_prod,
+        schedule.id,
+        "swap",
+    )
+
+    expected_archive = _expected_after(archive_uris, swap_in_uris, new_to_archive)
+    verify_playlist_state(
+        api,
+        archive_id,
+        expected_archive,
+        schedule.id,
+        "swap archive",
+    )
+
+    return swapped, len(verified_prod)

--- a/shuffify/services/source_resolver/public_scraper_pathway.py
+++ b/shuffify/services/source_resolver/public_scraper_pathway.py
@@ -42,10 +42,7 @@ REQUEST_HEADERS = {
         "AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/122.0.0.0 Safari/537.36"
     ),
-    "Accept": (
-        "text/html,application/xhtml+xml,"
-        "application/xml;q=0.9,*/*;q=0.8"
-    ),
+    "Accept": ("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     "Accept-Language": "en-US,en;q=0.9",
 }
 
@@ -184,9 +181,7 @@ class PublicScraperPathway:
         # Strategy 2: Public page (heavier, but may have more data)
         public = self._scrape_public_page(playlist_id)
         if public.uris:
-            self._set_cached(
-                playlist_id, public.uris, "public_page"
-            )
+            self._set_cached(playlist_id, public.uris, "public_page")
             return ResolveResult(
                 track_uris=public.uris,
                 pathway_name=self.name,
@@ -246,9 +241,7 @@ class PublicScraperPathway:
             label="Public page",
         )
 
-    def _do_scrape(
-        self, url: str, playlist_id: str, label: str
-    ) -> ScrapeOutcome:
+    def _do_scrape(self, url: str, playlist_id: str, label: str) -> ScrapeOutcome:
         """Fetch ``url`` and extract track URIs, classifying the outcome.
 
         Retries transient failures (429/5xx, network errors, timeouts) up
@@ -277,8 +270,7 @@ class PublicScraperPathway:
             ) as e:
                 last_error = f"{type(e).__name__}: {e}"
                 logger.warning(
-                    "%s scrape network error for %s "
-                    "(attempt %d/%d): %s",
+                    "%s scrape network error for %s (attempt %d/%d): %s",
                     label,
                     playlist_id,
                     attempt + 1,
@@ -332,8 +324,7 @@ class PublicScraperPathway:
             if status in TRANSIENT_STATUS_CODES:
                 last_error = f"HTTP {status}"
                 logger.warning(
-                    "%s returned %d for %s "
-                    "(transient, attempt %d/%d)",
+                    "%s returned %d for %s (transient, attempt %d/%d)",
                     label,
                     status,
                     playlist_id,
@@ -391,22 +382,17 @@ class PublicScraperPathway:
             now = datetime.now(timezone.utc)
             row = (
                 ScrapedPlaylistCache.query.filter(
-                    ScrapedPlaylistCache.playlist_id
-                    == playlist_id,
+                    ScrapedPlaylistCache.playlist_id == playlist_id,
                     ScrapedPlaylistCache.expires_at > now,
                 )
-                .order_by(
-                    ScrapedPlaylistCache.scraped_at.desc()
-                )
+                .order_by(ScrapedPlaylistCache.scraped_at.desc())
                 .first()
             )
             if row is None:
                 return None
             return row.track_uris
         except Exception as e:
-            logger.warning(
-                "Scraper cache read error: %s", e
-            )
+            logger.warning("Scraper cache read error: %s", e)
             return None
 
     @staticmethod
@@ -427,15 +413,13 @@ class PublicScraperPathway:
 
             # Delete expired rows for this playlist
             ScrapedPlaylistCache.query.filter(
-                ScrapedPlaylistCache.playlist_id
-                == playlist_id,
+                ScrapedPlaylistCache.playlist_id == playlist_id,
                 ScrapedPlaylistCache.expires_at <= now,
             ).delete()
 
             # Upsert: update existing or create new
             existing = ScrapedPlaylistCache.query.filter(
-                ScrapedPlaylistCache.playlist_id
-                == playlist_id,
+                ScrapedPlaylistCache.playlist_id == playlist_id,
             ).first()
 
             if existing:
@@ -444,12 +428,6 @@ class PublicScraperPathway:
                 existing.scrape_pathway = pathway
                 existing.expires_at = expires
             else:
-                # NOTE: ScrapedPlaylistCache.track_count is no longer
-                # written here — it was dead weight (no reader anywhere
-                # in the codebase). The column is intentionally left
-                # in the schema for now; a future cleanup PR can drop
-                # it via Alembic migration once a few releases have
-                # shipped without writers.
                 row = ScrapedPlaylistCache(
                     playlist_id=playlist_id,
                     scraped_at=now,
@@ -461,9 +439,7 @@ class PublicScraperPathway:
 
             db.session.commit()
         except Exception as e:
-            logger.warning(
-                "Scraper cache write error: %s", e
-            )
+            logger.warning("Scraper cache write error: %s", e)
             # L2: roll back so the session stays usable for
             # subsequent operations within the same request /
             # job. Without this, SQLAlchemy may leave the
@@ -508,9 +484,7 @@ def _get_request_timeout() -> int:
 # ======================================================================
 
 
-def _sleep_with_backoff(
-    attempt: int, retry_after: Optional[str] = None
-) -> None:
+def _sleep_with_backoff(attempt: int, retry_after: Optional[str] = None) -> None:
     """Sleep before the next retry attempt.
 
     Honors a server-provided ``Retry-After`` value (seconds) when present
@@ -682,9 +656,7 @@ def _walk_json_for_tracks(data: Any) -> List[str]:
                         return  # Found tracks, stop walking
 
             # Check for trackList pattern (embed-style)
-            if "trackList" in node and isinstance(
-                node["trackList"], list
-            ):
+            if "trackList" in node and isinstance(node["trackList"], list):
                 for item in node["trackList"]:
                     uri = _get_track_uri_from_item(item)
                     _collect(uri)
@@ -739,9 +711,7 @@ def _get_track_uri_from_item(item: Any) -> Optional[str]:
         return uri
 
     # Format 3: ID only — construct URI
-    track_id = item.get("id") or (
-        track.get("id") if isinstance(track, dict) else None
-    )
+    track_id = item.get("id") or (track.get("id") if isinstance(track, dict) else None)
     if isinstance(track_id, str) and len(track_id) == 22:
         return f"spotify:track:{track_id}"
 

--- a/shuffify/shuffle_algorithms/artist_spacing.py
+++ b/shuffify/shuffle_algorithms/artist_spacing.py
@@ -71,6 +71,13 @@ class ArtistSpacingShuffle(ShuffleAlgorithm):
         """
         min_spacing = kwargs.get("min_spacing", 1)
 
+        if not isinstance(min_spacing, int):
+            raise ValueError(
+                f"min_spacing must be an integer, got {type(min_spacing).__name__}"
+            )
+        if min_spacing < 1:
+            raise ValueError(f"min_spacing must be >= 1, got {min_spacing}")
+
         uris = extract_uris(tracks)
         if len(uris) <= 1:
             return uris

--- a/shuffify/shuffle_algorithms/percentage.py
+++ b/shuffify/shuffle_algorithms/percentage.py
@@ -41,7 +41,7 @@ class PercentageShuffle(ShuffleAlgorithm):
         self,
         tracks: List[Dict[str, Any]],
         features: Optional[Dict[str, Dict[str, Any]]] = None,
-        **kwargs
+        **kwargs,
     ) -> List[str]:
         """
         Shuffle a portion of the playlist while keeping the rest in order.
@@ -58,6 +58,19 @@ class PercentageShuffle(ShuffleAlgorithm):
         """
         shuffle_percentage = kwargs.get("shuffle_percentage", 50.0)
         shuffle_location = kwargs.get("shuffle_location", "front")
+
+        if not isinstance(shuffle_percentage, (int, float)):
+            raise ValueError(
+                f"shuffle_percentage must be numeric, got {type(shuffle_percentage).__name__}"
+            )
+        if not 0.0 <= shuffle_percentage <= 100.0:
+            raise ValueError(
+                f"shuffle_percentage must be between 0 and 100, got {shuffle_percentage}"
+            )
+        if shuffle_location not in ("front", "back"):
+            raise ValueError(
+                f"shuffle_location must be 'front' or 'back', got {shuffle_location!r}"
+            )
 
         uris = extract_uris(tracks)
 

--- a/shuffify/shuffle_algorithms/utils.py
+++ b/shuffify/shuffle_algorithms/utils.py
@@ -21,9 +21,7 @@ def extract_uris(tracks: List[Dict[str, Any]]) -> List[str]:
     return [track["uri"] for track in tracks if track.get("uri")]
 
 
-def split_keep_first(
-    uris: List[str], keep_first: int
-) -> Tuple[List[str], List[str]]:
+def split_keep_first(uris: List[str], keep_first: int) -> Tuple[List[str], List[str]]:
     """
     Split a URI list into kept (pinned) and shuffleable portions.
 
@@ -70,10 +68,7 @@ def split_locked_tracks(
                 validated[pos] = uri
                 locked_indices.add(pos)
 
-    unlocked = [
-        t for i, t in enumerate(tracks)
-        if i not in locked_indices
-    ]
+    unlocked = [t for i, t in enumerate(tracks) if i not in locked_indices]
     return validated, unlocked
 
 
@@ -93,6 +88,9 @@ def reassemble_with_locks(
 
     Returns:
         Complete URI list with locks in place.
+
+    Raises:
+        ValueError: If shuffled_uris exceed available unlocked slots.
     """
     if not locked_positions:
         return shuffled_uris
@@ -104,6 +102,15 @@ def reassemble_with_locks(
         if 0 <= pos < total_length:
             result[pos] = uri
 
+    available_slots = sum(1 for r in result if r is None)
+    if len(shuffled_uris) > available_slots:
+        raise ValueError(
+            f"reassemble_with_locks: {len(shuffled_uris)} URIs "
+            f"exceed {available_slots} available slots "
+            f"(total_length={total_length}, "
+            f"locked={total_length - available_slots})"
+        )
+
     unlocked_idx = 0
     for i in range(total_length):
         if result[i] is None:
@@ -114,9 +121,7 @@ def reassemble_with_locks(
     return [u for u in result if u is not None]
 
 
-def split_into_sections(
-    items: List[str], section_count: int
-) -> List[List[str]]:
+def split_into_sections(items: List[str], section_count: int) -> List[List[str]]:
     """
     Divide a list into N sections of roughly equal size.
 

--- a/shuffify/spotify/api.py
+++ b/shuffify/spotify/api.py
@@ -92,9 +92,7 @@ class SpotifyAPI:
         self._http = SpotifyHTTPClient(
             token_info.access_token,
             on_token_refresh=(
-                self._handle_token_refresh
-                if self._auto_refresh
-                else None
+                self._handle_token_refresh if self._auto_refresh else None
             ),
         )
         self._user_id: Optional[str] = None
@@ -105,9 +103,7 @@ class SpotifyAPI:
 
     def _handle_token_refresh(self) -> str:
         """Callback for SpotifyHTTPClient on 401 responses."""
-        self._token_info = self._auth_manager.ensure_valid_token(
-            self._token_info
-        )
+        self._token_info = self._auth_manager.ensure_valid_token(self._token_info)
         return self._token_info.access_token
 
     @property
@@ -131,14 +127,10 @@ class SpotifyAPI:
             return
 
         if not self._auto_refresh:
-            raise SpotifyTokenExpiredError(
-                "Token expired and auto-refresh disabled"
-            )
+            raise SpotifyTokenExpiredError("Token expired and auto-refresh disabled")
 
         logger.info("Token expired, refreshing...")
-        self._token_info = self._auth_manager.ensure_valid_token(
-            self._token_info
-        )
+        self._token_info = self._auth_manager.ensure_valid_token(self._token_info)
         self._http.update_token(self._token_info.access_token)
 
     def _get_user_id(self) -> str:
@@ -172,9 +164,7 @@ class SpotifyAPI:
                 return cached
 
         user = self._http.get("/me")
-        logger.debug(
-            f"Retrieved user: {user.get('display_name', 'Unknown')}"
-        )
+        logger.debug(f"Retrieved user: {user.get('display_name', 'Unknown')}")
 
         # Cache the result
         if self._cache and user:
@@ -188,9 +178,7 @@ class SpotifyAPI:
     # =========================================================================
 
     @api_error_handler
-    def get_user_playlists(
-        self, skip_cache: bool = False
-    ) -> List[Dict[str, Any]]:
+    def get_user_playlists(self, skip_cache: bool = False) -> List[Dict[str, Any]]:
         """
         Get all playlists the user can edit.
 
@@ -217,15 +205,10 @@ class SpotifyAPI:
         all_items = self._http.get_all_pages("/me/playlists")
         for playlist in all_items:
             # Include playlists the user owns or can collaborate on
-            if (
-                playlist["owner"]["id"] == user_id
-                or playlist.get("collaborative")
-            ):
+            if playlist["owner"]["id"] == user_id or playlist.get("collaborative"):
                 playlists.append(playlist)
 
-        logger.debug(
-            f"Retrieved {len(playlists)} editable playlists"
-        )
+        logger.debug(f"Retrieved {len(playlists)} editable playlists")
 
         # Cache the result
         if self._cache:
@@ -260,9 +243,7 @@ class SpotifyAPI:
                 return cached
 
         playlist = self._http.get(f"/playlists/{playlist_id}")
-        logger.debug(
-            f"Retrieved playlist: {playlist.get('name', 'Unknown')}"
-        )
+        logger.debug(f"Retrieved playlist: {playlist.get('name', 'Unknown')}")
 
         # Cache the result
         if self._cache:
@@ -298,9 +279,7 @@ class SpotifyAPI:
 
         tracks = []
 
-        all_items = self._http.get_all_pages(
-            f"/playlists/{playlist_id}/items"
-        )
+        all_items = self._http.get_all_pages(f"/playlists/{playlist_id}/items")
         for item in all_items:
             # TODO: Spotify API migrating from "track" to "item"
             # key (announced Feb 2026). Use "track" as primary
@@ -314,10 +293,7 @@ class SpotifyAPI:
                     track["added_at"] = item["added_at"]
                 tracks.append(track)
 
-        logger.debug(
-            f"Retrieved {len(tracks)} tracks from playlist "
-            f"{playlist_id}"
-        )
+        logger.debug(f"Retrieved {len(tracks)} tracks from playlist {playlist_id}")
 
         # Cache the result
         if self._cache:
@@ -326,9 +302,7 @@ class SpotifyAPI:
         return tracks
 
     @api_error_handler
-    def update_playlist_tracks(
-        self, playlist_id: str, track_uris: List[str]
-    ) -> bool:
+    def update_playlist_tracks(self, playlist_id: str, track_uris: List[str]) -> bool:
         """
         Replace all tracks in a playlist with a new list.
 
@@ -360,10 +334,7 @@ class SpotifyAPI:
                 self._cache.invalidate_playlist(playlist_id)
             return True
 
-        total_batches = (
-            (len(track_uris) + self.BATCH_SIZE - 1)
-            // self.BATCH_SIZE
-        )
+        total_batches = (len(track_uris) + self.BATCH_SIZE - 1) // self.BATCH_SIZE
         completed: List[str] = []
 
         # Batch 1: PUT (replaces playlist contents)
@@ -392,7 +363,7 @@ class SpotifyAPI:
             range(self.BATCH_SIZE, len(track_uris), self.BATCH_SIZE),
             start=1,
         ):
-            batch = track_uris[i: i + self.BATCH_SIZE]
+            batch = track_uris[i : i + self.BATCH_SIZE]
             try:
                 self._http.post(
                     f"/playlists/{playlist_id}/items",
@@ -415,10 +386,7 @@ class SpotifyAPI:
                 )
             completed.extend(batch)
 
-        logger.info(
-            f"Updated playlist {playlist_id} with "
-            f"{len(track_uris)} tracks"
-        )
+        logger.info(f"Updated playlist {playlist_id} with {len(track_uris)} tracks")
 
         if self._cache:
             self._cache.invalidate_playlist(playlist_id)
@@ -428,9 +396,7 @@ class SpotifyAPI:
         return True
 
     @api_error_handler
-    def get_tracks(
-        self, track_uris: List[str]
-    ) -> List[Dict[str, Any]]:
+    def get_tracks(self, track_uris: List[str]) -> List[Dict[str, Any]]:
         """
         Fetch full track metadata for a list of track URIs.
 
@@ -455,7 +421,7 @@ class SpotifyAPI:
         tracks = []
         batch_size = 50  # Spotify limit for /tracks
         for i in range(0, len(ids), batch_size):
-            batch = ids[i: i + batch_size]
+            batch = ids[i : i + batch_size]
             result = self._http.get(
                 "/tracks",
                 params={"ids": ",".join(batch)},
@@ -498,16 +464,11 @@ class SpotifyAPI:
         if not track_uris:
             return True
 
-        total_batches = (
-            (len(track_uris) + self.BATCH_SIZE - 1)
-            // self.BATCH_SIZE
-        )
+        total_batches = (len(track_uris) + self.BATCH_SIZE - 1) // self.BATCH_SIZE
         completed: List[str] = []
 
-        for batch_idx, i in enumerate(
-            range(0, len(track_uris), self.BATCH_SIZE)
-        ):
-            batch = track_uris[i: i + self.BATCH_SIZE]
+        for batch_idx, i in enumerate(range(0, len(track_uris), self.BATCH_SIZE)):
+            batch = track_uris[i : i + self.BATCH_SIZE]
             payload: Dict[str, Any] = {"uris": batch}
             if position is not None:
                 payload["position"] = position + i
@@ -538,9 +499,7 @@ class SpotifyAPI:
         return True
 
     @api_error_handler
-    def playlist_remove_items(
-        self, playlist_id: str, track_uris: List[str]
-    ) -> bool:
+    def playlist_remove_items(self, playlist_id: str, track_uris: List[str]) -> bool:
         """
         Remove specific tracks from a playlist.
 
@@ -567,24 +526,15 @@ class SpotifyAPI:
         if not track_uris:
             return True
 
-        total_batches = (
-            (len(track_uris) + self.BATCH_SIZE - 1)
-            // self.BATCH_SIZE
-        )
+        total_batches = (len(track_uris) + self.BATCH_SIZE - 1) // self.BATCH_SIZE
         completed: List[str] = []
 
-        for batch_idx, i in enumerate(
-            range(0, len(track_uris), self.BATCH_SIZE)
-        ):
-            batch = track_uris[i: i + self.BATCH_SIZE]
+        for batch_idx, i in enumerate(range(0, len(track_uris), self.BATCH_SIZE)):
+            batch = track_uris[i : i + self.BATCH_SIZE]
             try:
                 self._http.delete(
                     f"/playlists/{playlist_id}/tracks",
-                    json={
-                        "tracks": [
-                            {"uri": u} for u in batch
-                        ]
-                    },
+                    json={"tracks": [{"uri": u} for u in batch]},
                 )
             except SpotifyAPIError as e:
                 if self._cache and batch_idx > 0:
@@ -602,15 +552,14 @@ class SpotifyAPI:
 
         logger.info(
             "Removed %d tracks from playlist %s",
-            len(track_uris), playlist_id,
+            len(track_uris),
+            playlist_id,
         )
 
         if self._cache:
             self._cache.invalidate_playlist(playlist_id)
             if self._user_id:
-                self._cache.invalidate_user_playlists(
-                    self._user_id
-                )
+                self._cache.invalidate_user_playlists(self._user_id)
 
         return True
 
@@ -664,10 +613,7 @@ class SpotifyAPI:
         self._ensure_valid_token()
 
         allowed = {"name", "public", "description"}
-        body = {
-            k: v for k, v in kwargs.items()
-            if k in allowed
-        }
+        body = {k: v for k, v in kwargs.items() if k in allowed}
         if not body:
             return
 
@@ -739,9 +685,7 @@ class SpotifyAPI:
         valid_ids = []
         for tid in track_ids:
             if tid:
-                clean_id = (
-                    tid.split(":")[-1] if ":" in tid else tid
-                )
+                clean_id = tid.split(":")[-1] if ":" in tid else tid
                 valid_ids.append(clean_id)
 
         if not valid_ids:
@@ -750,40 +694,23 @@ class SpotifyAPI:
         # Check cache first
         ids_to_fetch = valid_ids
         if self._cache and not skip_cache:
-            cached_features = self._cache.get_audio_features(
-                valid_ids
-            )
+            cached_features = self._cache.get_audio_features(valid_ids)
             features.update(cached_features)
-            ids_to_fetch = [
-                tid
-                for tid in valid_ids
-                if tid not in cached_features
-            ]
+            ids_to_fetch = [tid for tid in valid_ids if tid not in cached_features]
             if not ids_to_fetch:
-                logger.debug(
-                    f"All {len(valid_ids)} audio features "
-                    f"from cache"
-                )
+                logger.debug(f"All {len(valid_ids)} audio features from cache")
                 return features
 
         # Fetch uncached in batches
         new_features = {}
-        for i in range(
-            0, len(ids_to_fetch), self.AUDIO_FEATURES_BATCH_SIZE
-        ):
-            batch = ids_to_fetch[
-                i: i + self.AUDIO_FEATURES_BATCH_SIZE
-            ]
+        for i in range(0, len(ids_to_fetch), self.AUDIO_FEATURES_BATCH_SIZE):
+            batch = ids_to_fetch[i : i + self.AUDIO_FEATURES_BATCH_SIZE]
             result = self._http.get(
                 "/audio-features",
                 params={"ids": ",".join(batch)},
             )
 
-            results = (
-                result.get("audio_features", [])
-                if result
-                else []
-            )
+            results = result.get("audio_features", []) if result else []
             if results:
                 for track_id, feature in zip(batch, results):
                     if feature:
@@ -791,8 +718,7 @@ class SpotifyAPI:
                         new_features[track_id] = feature
 
         logger.debug(
-            f"Retrieved audio features for "
-            f"{len(new_features)} tracks (from API)"
+            f"Retrieved audio features for {len(new_features)} tracks (from API)"
         )
 
         # Cache the new results
@@ -817,7 +743,7 @@ class SpotifyAPI:
 
         Args:
             query: Search query string.
-            limit: Maximum number of results (1-10, default 10).
+            limit: Maximum number of results (1-50, default 10).
             skip_cache: If True, bypass cache and fetch fresh data.
 
         Returns:
@@ -830,7 +756,7 @@ class SpotifyAPI:
         self._ensure_valid_token()
 
         # Clamp limit to Spotify's allowed range
-        limit = max(1, min(limit, 10))
+        limit = max(1, min(limit, 50))
 
         # Check cache first
         if self._cache and not skip_cache:
@@ -844,51 +770,34 @@ class SpotifyAPI:
         )
 
         playlists = []
-        if (
-            results
-            and "playlists" in results
-            and "items" in results["playlists"]
-        ):
+        if results and "playlists" in results and "items" in results["playlists"]:
             for item in results["playlists"]["items"]:
                 if item is None:
                     continue
                 # Defensive fallback: search response may use
                 # "items" or "tracks" for the total count depending
                 # on API version. Handle both safely.
-                total_key = item.get(
-                    "items", item.get("tracks", {})
-                )
+                total_key = item.get("items", item.get("tracks", {}))
                 playlists.append(
                     {
                         "id": item["id"],
                         "name": item["name"],
-                        "owner_display_name": item.get(
-                            "owner", {}
-                        ).get("display_name", "Unknown"),
-                        "owner_id": item.get(
-                            "owner", {}
-                        ).get("id", ""),
+                        "owner_display_name": item.get("owner", {}).get(
+                            "display_name", "Unknown"
+                        ),
+                        "owner_id": item.get("owner", {}).get("id", ""),
                         "image_url": (
-                            item["images"][0]["url"]
-                            if item.get("images")
-                            else None
+                            item["images"][0]["url"] if item.get("images") else None
                         ),
-                        "total_tracks": total_key.get(
-                            "total", 0
-                        ),
+                        "total_tracks": total_key.get("total", 0),
                     }
                 )
 
-        logger.debug(
-            f"Playlist search for '{query}' returned "
-            f"{len(playlists)} results"
-        )
+        logger.debug(f"Playlist search for '{query}' returned {len(playlists)} results")
 
         # Cache the results
         if self._cache and playlists:
-            self._cache.set_search_playlists(
-                query, limit, playlists
-            )
+            self._cache.set_search_playlists(query, limit, playlists)
 
         return playlists
 
@@ -906,7 +815,7 @@ class SpotifyAPI:
 
         Args:
             query: Search query string.
-            limit: Maximum number of results (1-10, default 10).
+            limit: Maximum number of results (1-50, default 10).
             offset: Result offset for pagination (default 0).
             market: ISO 3166-1 alpha-2 country code.
             skip_cache: If True, bypass cache and fetch fresh data.
@@ -920,7 +829,7 @@ class SpotifyAPI:
         self._ensure_valid_token()
 
         # Clamp limit to Spotify's maximum
-        limit = max(1, min(limit, 10))
+        limit = max(1, min(limit, 50))
         offset = max(0, offset)
 
         # Check cache first
@@ -941,11 +850,7 @@ class SpotifyAPI:
         results = self._http.get("/search", params=params)
 
         tracks = []
-        if (
-            results
-            and "tracks" in results
-            and "items" in results["tracks"]
-        ):
+        if results and "tracks" in results and "items" in results["tracks"]:
             for item in results["tracks"]["items"]:
                 if item and item.get("uri"):
                     tracks.append(item)

--- a/shuffify/spotify/auth.py
+++ b/shuffify/spotify/auth.py
@@ -8,7 +8,7 @@ separating them from data operations.
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, Any, Optional
 from urllib.parse import urlencode
 
@@ -57,9 +57,6 @@ class TokenInfo:
     scope: Optional[str] = None
     expires_in: Optional[int] = None
 
-    # Original dict for compatibility
-    _raw: Dict[str, Any] = field(default_factory=dict, repr=False)
-
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TokenInfo":
         """
@@ -97,7 +94,6 @@ class TokenInfo:
             refresh_token=data.get("refresh_token"),
             scope=data.get("scope"),
             expires_in=data.get("expires_in"),
-            _raw=data.copy(),
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/shuffify/spotify/http_client.py
+++ b/shuffify/spotify/http_client.py
@@ -29,7 +29,7 @@ MAX_DELAY = 16  # seconds
 
 def _calculate_backoff_delay(attempt: int) -> float:
     """Calculate exponential backoff delay, capped at MAX_DELAY."""
-    return min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+    return min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
 
 class SpotifyHTTPClient:
@@ -56,10 +56,12 @@ class SpotifyHTTPClient:
         self._access_token = access_token
         self._on_token_refresh = on_token_refresh
         self._session = requests.Session()
-        self._session.headers.update({
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-        })
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            }
+        )
 
     def update_token(self, access_token: str) -> None:
         """Update the bearer token for future requests."""
@@ -159,11 +161,16 @@ class SpotifyHTTPClient:
         On 401, attempts a single token refresh before failing.
         """
         token_refreshed = False
+        attempt = 0
 
-        for attempt in range(MAX_RETRIES + 1):
+        while attempt <= MAX_RETRIES:
             try:
                 response = self._session.request(
-                    method, url, params=params, json=json, timeout=30,
+                    method,
+                    url,
+                    params=params,
+                    json=json,
+                    timeout=30,
                 )
 
                 # --- Success ---
@@ -180,41 +187,37 @@ class SpotifyHTTPClient:
                             new_token = self._on_token_refresh()
                             self.update_token(new_token)
                             token_refreshed = True
+                            attempt = 0  # reset retry budget after refresh
                             continue
                         except Exception as e:
                             logger.error("Token refresh failed: %s", e)
-                    raise SpotifyTokenExpiredError(
-                        "Token expired or invalid"
-                    )
+                    raise SpotifyTokenExpiredError("Token expired or invalid")
 
                 # --- 404 Not Found ---
                 if response.status_code == 404:
-                    raise SpotifyNotFoundError(
-                        f"Resource not found: {url}"
-                    )
+                    raise SpotifyNotFoundError(f"Resource not found: {url}")
 
                 # --- 429 Rate Limited ---
                 if response.status_code == 429:
                     if attempt >= MAX_RETRIES:
-                        retry_after = int(
-                            response.headers.get("Retry-After", 60)
-                        )
+                        retry_after = int(response.headers.get("Retry-After", 60))
                         raise SpotifyRateLimitError(
                             f"Rate limited after {MAX_RETRIES + 1} attempts",
                             retry_after=retry_after,
                         )
-                    retry_after = int(
-                        response.headers.get("Retry-After", 1)
-                    )
+                    retry_after = int(response.headers.get("Retry-After", 1))
                     delay = max(
                         retry_after,
                         _calculate_backoff_delay(attempt),
                     )
                     logger.warning(
                         "Rate limited (429), retry %d/%d in %ss",
-                        attempt + 1, MAX_RETRIES + 1, delay,
+                        attempt + 1,
+                        MAX_RETRIES + 1,
+                        delay,
                     )
                     time.sleep(delay)
+                    attempt += 1
                     continue
 
                 # --- 5xx Server Error ---
@@ -228,35 +231,37 @@ class SpotifyHTTPClient:
                     logger.warning(
                         "Server error %d, retry %d/%d in %ss",
                         response.status_code,
-                        attempt + 1, MAX_RETRIES + 1, delay,
+                        attempt + 1,
+                        MAX_RETRIES + 1,
+                        delay,
                     )
                     time.sleep(delay)
+                    attempt += 1
                     continue
 
                 # --- Other client errors (400, 403, etc.) ---
                 try:
                     body = response.json()
-                    msg = body.get("error", {}).get(
-                        "message", response.text
-                    )
+                    msg = body.get("error", {}).get("message", response.text)
                 except Exception:
                     msg = response.text
-                raise SpotifyAPIError(
-                    f"API error {response.status_code}: {msg}"
-                )
+                raise SpotifyAPIError(f"API error {response.status_code}: {msg}")
 
             except (ConnectionError, Timeout, RequestException) as e:
                 if attempt >= MAX_RETRIES:
                     raise SpotifyAPIError(
-                        f"Network error after {MAX_RETRIES + 1} "
-                        f"attempts: {e}"
+                        f"Network error after {MAX_RETRIES + 1} attempts: {e}"
                     )
                 delay = _calculate_backoff_delay(attempt)
                 logger.warning(
                     "Network error, retry %d/%d in %ss: %s",
-                    attempt + 1, MAX_RETRIES + 1, delay, e,
+                    attempt + 1,
+                    MAX_RETRIES + 1,
+                    delay,
+                    e,
                 )
                 time.sleep(delay)
+                attempt += 1
 
             except (
                 SpotifyNotFoundError,
@@ -267,6 +272,4 @@ class SpotifyHTTPClient:
                 raise
 
         # Should not reach here
-        raise SpotifyAPIError(
-            f"Request failed after {MAX_RETRIES + 1} attempts"
-        )
+        raise SpotifyAPIError(f"Request failed after {MAX_RETRIES + 1} attempts")

--- a/tests/services/source_resolver/test_public_scraper_pathway.py
+++ b/tests/services/source_resolver/test_public_scraper_pathway.py
@@ -349,7 +349,7 @@ class TestExtractFromTrackList:
         assert _extract_from_track_list(html) == []
 
     def test_invalid_json_in_script(self):
-        html = '<script>trackList is not JSON</script>'
+        html = "<script>trackList is not JSON</script>"
         assert _extract_from_track_list(html) == []
 
     def test_track_list_not_a_list(self):
@@ -425,10 +425,7 @@ class TestExtractWithRegex:
 
     def test_deduplicates_across_patterns(self):
         result = _extract_with_regex(MIXED_LEGACY_HTML)
-        uris = [
-            u for u in result
-            if u == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
-        ]
+        uris = [u for u in result if u == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"]
         assert len(uris) == 1
 
     def test_empty_html(self):
@@ -498,31 +495,19 @@ class TestGetTrackUriFromItem:
 
     def test_nested_track_uri(self):
         item = {"track": {"uri": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"}}
-        assert (
-            _get_track_uri_from_item(item)
-            == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
-        )
+        assert _get_track_uri_from_item(item) == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
 
     def test_flat_uri(self):
         item = {"uri": "spotify:track:bbbbbbbbbbbbbbbbbbbbbb"}
-        assert (
-            _get_track_uri_from_item(item)
-            == "spotify:track:bbbbbbbbbbbbbbbbbbbbbb"
-        )
+        assert _get_track_uri_from_item(item) == "spotify:track:bbbbbbbbbbbbbbbbbbbbbb"
 
     def test_id_only_nested(self):
         item = {"track": {"id": "aaaaaaaaaaaaaaaaaaaaaa"}}
-        assert (
-            _get_track_uri_from_item(item)
-            == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
-        )
+        assert _get_track_uri_from_item(item) == "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
 
     def test_id_only_flat(self):
         item = {"id": "bbbbbbbbbbbbbbbbbbbbbb"}
-        assert (
-            _get_track_uri_from_item(item)
-            == "spotify:track:bbbbbbbbbbbbbbbbbbbbbb"
-        )
+        assert _get_track_uri_from_item(item) == "spotify:track:bbbbbbbbbbbbbbbbbbbbbb"
 
     def test_non_track_uri_ignored(self):
         item = {"uri": "spotify:album:aaaaaaaaaaaaaaaaaaaaaa"}
@@ -562,7 +547,11 @@ class TestWalkJsonForTracks:
                     "c": {
                         "tracks": {
                             "items": [
-                                {"track": {"uri": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"}}
+                                {
+                                    "track": {
+                                        "uri": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"
+                                    }
+                                }
                             ]
                         }
                     }
@@ -577,9 +566,9 @@ class TestWalkJsonForTracks:
         assert _walk_json_for_tracks({"data": {}}) == []
 
     def test_handles_lists(self):
-        data = [{"tracks": {"items": [
-            {"uri": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"}
-        ]}}]
+        data = [
+            {"tracks": {"items": [{"uri": "spotify:track:aaaaaaaaaaaaaaaaaaaaaa"}]}}
+        ]
         result = _walk_json_for_tracks(data)
         assert len(result) == 1
 
@@ -662,16 +651,9 @@ class TestCanHandle:
 class TestResolve:
     """Tests for PublicScraperPathway.resolve()."""
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_embed_success_with_next_data(
-        self, mock_get, pathway, mock_source
-    ):
-        resp = Mock(
-            status_code=200, text=NEXT_DATA_TRACKS_ITEMS_HTML
-        )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_embed_success_with_next_data(self, mock_get, pathway, mock_source):
+        resp = Mock(status_code=200, text=NEXT_DATA_TRACKS_ITEMS_HTML)
         mock_get.return_value = resp
 
         result = pathway.resolve(mock_source)
@@ -680,16 +662,9 @@ class TestResolve:
         assert len(result.track_uris) == 3
         assert mock_get.call_count == 1
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_embed_success_with_track_list(
-        self, mock_get, pathway, mock_source
-    ):
-        resp = Mock(
-            status_code=200, text=SCRIPT_TRACK_LIST_HTML
-        )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_embed_success_with_track_list(self, mock_get, pathway, mock_source):
+        resp = Mock(status_code=200, text=SCRIPT_TRACK_LIST_HTML)
         mock_get.return_value = resp
 
         result = pathway.resolve(mock_source)
@@ -697,67 +672,41 @@ class TestResolve:
         assert len(result.track_uris) == 2
         assert mock_get.call_count == 1
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_embed_success_with_regex_fallback(
-        self, mock_get, pathway, mock_source
-    ):
-        resp = Mock(
-            status_code=200, text=LEGACY_URI_HTML
-        )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_embed_success_with_regex_fallback(self, mock_get, pathway, mock_source):
+        resp = Mock(status_code=200, text=LEGACY_URI_HTML)
         mock_get.return_value = resp
 
         result = pathway.resolve(mock_source)
         assert result.success is True
         assert len(result.track_uris) == 2
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_embed_fails_falls_to_public_page(
-        self, mock_get, pathway, mock_source
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_embed_fails_falls_to_public_page(self, mock_get, pathway, mock_source):
         embed_resp = Mock(status_code=404, text="")
-        page_resp = Mock(
-            status_code=200, text=LEGACY_URL_HTML
-        )
+        page_resp = Mock(status_code=200, text=LEGACY_URL_HTML)
         mock_get.side_effect = [embed_resp, page_resp]
 
         result = pathway.resolve(mock_source)
         assert result.success is True
         assert mock_get.call_count == 2
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_both_strategies_fail(
-        self, mock_get, pathway, mock_source
-    ):
-        mock_get.return_value = Mock(
-            status_code=200, text="<html></html>"
-        )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_both_strategies_fail(self, mock_get, pathway, mock_source):
+        mock_get.return_value = Mock(status_code=200, text="<html></html>")
 
         result = pathway.resolve(mock_source)
         assert result.success is False
         assert "no tracks" in result.error_message.lower()
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_http_error(self, mock_get, pathway, mock_source):
         mock_get.side_effect = Exception("Connection refused")
         result = pathway.resolve(mock_source)
         assert result.success is False
 
     def test_no_playlist_id(self, pathway):
-        source = Mock(
-            source_playlist_id=None, source_type="external"
-        )
+        source = Mock(source_playlist_id=None, source_type="external")
         result = pathway.resolve(source)
         assert result.success is False
         assert "No playlist ID" in result.error_message
@@ -767,24 +716,15 @@ class TestResolve:
     def test_name_property(self, pathway):
         assert pathway.name == "public_scraper"
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_browser_headers_sent(
-        self, mock_get, pathway, mock_source
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_browser_headers_sent(self, mock_get, pathway, mock_source):
         """Verify browser-like headers are used for requests."""
-        mock_get.return_value = Mock(
-            status_code=200, text=NEXT_DATA_TRACKS_ITEMS_HTML
-        )
+        mock_get.return_value = Mock(status_code=200, text=NEXT_DATA_TRACKS_ITEMS_HTML)
 
         pathway.resolve(mock_source)
 
         call_kwargs = mock_get.call_args
-        headers = call_kwargs.kwargs.get(
-            "headers", call_kwargs[1].get("headers", {})
-        )
+        headers = call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))
         assert "Mozilla" in headers.get("User-Agent", "")
         assert "Accept" in headers
 
@@ -797,20 +737,18 @@ class TestResolve:
 class TestCaching:
     """Tests for database cache integration."""
 
-    def test_cache_hit_returns_cached(
-        self, mock_source, db_app
-    ):
+    def test_cache_hit_returns_cached(self, mock_source, db_app):
         """Pre-populated cache row is returned directly."""
         from datetime import datetime, timedelta, timezone
         from shuffify.models.db import (
-            ScrapedPlaylistCache, db,
+            ScrapedPlaylistCache,
+            db,
         )
 
         with db_app.app_context():
             now = datetime.now(timezone.utc)
             row = ScrapedPlaylistCache(
                 playlist_id="pl_test123",
-                track_count=2,
                 scraped_at=now,
                 scrape_pathway="embed",
                 expires_at=now + timedelta(hours=1),
@@ -827,20 +765,18 @@ class TestCaching:
             assert result.success is True
             assert len(result.track_uris) == 2
 
-    def test_cache_hit_empty_returns_failure(
-        self, mock_source, db_app
-    ):
+    def test_cache_hit_empty_returns_failure(self, mock_source, db_app):
         """Cached empty result returns failure."""
         from datetime import datetime, timedelta, timezone
         from shuffify.models.db import (
-            ScrapedPlaylistCache, db,
+            ScrapedPlaylistCache,
+            db,
         )
 
         with db_app.app_context():
             now = datetime.now(timezone.utc)
             row = ScrapedPlaylistCache(
                 playlist_id="pl_test123",
-                track_count=0,
                 scraped_at=now,
                 scrape_pathway="none",
                 expires_at=now + timedelta(hours=1),
@@ -853,13 +789,8 @@ class TestCaching:
             result = pathway.resolve(mock_source)
             assert result.success is False
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_cache_miss_fetches_and_stores(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_cache_miss_fetches_and_stores(self, mock_get, mock_source, db_app):
         """Cache miss triggers scraping and stores result."""
         from shuffify.models.db import (
             ScrapedPlaylistCache,
@@ -875,12 +806,7 @@ class TestCaching:
             result = pathway.resolve(mock_source)
             assert result.success is True
 
-            # Verify cache row was created. ``track_count`` is no
-            # longer written by the scraper (issue #318 — dead field);
-            # callers should derive the count from ``track_uris``.
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is not None
             assert len(row.track_uris) > 0
             assert row.scrape_pathway == "embed"
@@ -888,36 +814,24 @@ class TestCaching:
     def test_cache_read_error_returns_none(self, db_app):
         """DB errors in _get_cached return None gracefully."""
         with db_app.app_context():
-            with patch(
-                "shuffify.models.db"
-                ".ScrapedPlaylistCache.query"
-            ) as mock_q:
-                mock_q.filter.side_effect = Exception(
-                    "DB down"
-                )
-                result = PublicScraperPathway._get_cached(
-                    "pl_test123"
-                )
+            with patch("shuffify.models.db.ScrapedPlaylistCache.query") as mock_q:
+                mock_q.filter.side_effect = Exception("DB down")
+                result = PublicScraperPathway._get_cached("pl_test123")
                 assert result is None
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_expired_cache_triggers_rescrape(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_expired_cache_triggers_rescrape(self, mock_get, mock_source, db_app):
         """Expired cache row is ignored; fresh scrape runs."""
         from datetime import datetime, timedelta, timezone
         from shuffify.models.db import (
-            ScrapedPlaylistCache, db,
+            ScrapedPlaylistCache,
+            db,
         )
 
         with db_app.app_context():
             now = datetime.now(timezone.utc)
             row = ScrapedPlaylistCache(
                 playlist_id="pl_test123",
-                track_count=1,
                 scraped_at=now - timedelta(hours=2),
                 scrape_pathway="embed",
                 expires_at=now - timedelta(hours=1),
@@ -937,38 +851,26 @@ class TestCaching:
             result = pathway.resolve(mock_source)
             assert result.success is True
             # Should have new tracks, not the old cached one
-            assert (
-                "spotify:track:oldoldoldoldoldoldoldold"
-                not in result.track_uris
-            )
+            assert "spotify:track:oldoldoldoldoldoldoldold" not in result.track_uris
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_failed_scrape_caches_empty(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_failed_scrape_caches_empty(self, mock_get, mock_source, db_app):
         """Both strategies failing still caches empty."""
         from shuffify.models.db import (
             ScrapedPlaylistCache,
         )
 
         with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=200, text="<html></html>"
-            )
+            mock_get.return_value = Mock(status_code=200, text="<html></html>")
 
             pathway = PublicScraperPathway()
             result = pathway.resolve(mock_source)
             assert result.success is False
 
             # Verify empty was cached
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is not None
-            assert row.track_count == 0
+            assert len(row.track_uris) == 0
 
 
 # ======================================================================
@@ -987,13 +889,8 @@ class TestCachePoisoningRegression:
     the cache.
     """
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_403_response_does_not_cache(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_403_response_does_not_cache(self, mock_get, mock_source, db_app):
         from shuffify.models.db import ScrapedPlaylistCache
 
         with db_app.app_context():
@@ -1003,47 +900,31 @@ class TestCachePoisoningRegression:
 
             assert result.success is False
             assert "unconfirmed" in result.error_message.lower()
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is None, (
-                "403 must not poison the cache — next raid "
-                "should be free to retry"
+                "403 must not poison the cache — next raid should be free to retry"
             )
 
     @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway._sleep_with_backoff"
+        "shuffify.services.source_resolver.public_scraper_pathway._sleep_with_backoff"
     )
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_429_response_does_not_cache(
         self, mock_get, mock_sleep, mock_source, db_app
     ):
         from shuffify.models.db import ScrapedPlaylistCache
 
         with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=429, text="", headers={}
-            )
+            mock_get.return_value = Mock(status_code=429, text="", headers={})
             pathway = PublicScraperPathway()
             result = pathway.resolve(mock_source)
 
             assert result.success is False
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is None
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_network_exception_does_not_cache(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_network_exception_does_not_cache(self, mock_get, mock_source, db_app):
         from shuffify.models.db import ScrapedPlaylistCache
 
         with db_app.app_context():
@@ -1052,15 +933,10 @@ class TestCachePoisoningRegression:
             result = pathway.resolve(mock_source)
 
             assert result.success is False
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is None
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_mixed_embed_403_then_public_200_with_tracks_caches(
         self, mock_get, mock_source, db_app
     ):
@@ -1070,9 +946,7 @@ class TestCachePoisoningRegression:
 
         with db_app.app_context():
             embed_resp = Mock(status_code=403, text="")
-            page_resp = Mock(
-                status_code=200, text=LEGACY_URL_HTML
-            )
+            page_resp = Mock(status_code=200, text=LEGACY_URL_HTML)
             mock_get.side_effect = [embed_resp, page_resp]
 
             pathway = PublicScraperPathway()
@@ -1080,18 +954,11 @@ class TestCachePoisoningRegression:
 
             assert result.success is True
             assert len(result.track_uris) > 0
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is not None
-            # ``track_count`` is no longer written by the scraper
-            # (issue #318); derive the count from ``track_uris``.
             assert len(row.track_uris) == len(result.track_uris)
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_mixed_embed_403_then_public_403_does_not_cache(
         self, mock_get, mock_source, db_app
     ):
@@ -1108,18 +975,11 @@ class TestCachePoisoningRegression:
             result = pathway.resolve(mock_source)
 
             assert result.success is False
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is None
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_confirmed_empty_still_caches(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_confirmed_empty_still_caches(self, mock_get, mock_source, db_app):
         """A 200 response with no extractable tracks IS a confirmed
         empty playlist — cache it so we don't re-scrape repeatedly.
 
@@ -1129,19 +989,15 @@ class TestCachePoisoningRegression:
         from shuffify.models.db import ScrapedPlaylistCache
 
         with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=200, text="<html></html>"
-            )
+            mock_get.return_value = Mock(status_code=200, text="<html></html>")
 
             pathway = PublicScraperPathway()
             result = pathway.resolve(mock_source)
 
             assert result.success is False
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is not None
-            assert row.track_count == 0
+            assert len(row.track_uris) == 0
 
 
 # ======================================================================
@@ -1149,10 +1005,7 @@ class TestCachePoisoningRegression:
 # ======================================================================
 
 
-@patch(
-    "shuffify.services.source_resolver"
-    ".public_scraper_pathway._sleep_with_backoff"
-)
+@patch("shuffify.services.source_resolver.public_scraper_pathway._sleep_with_backoff")
 class TestRetryBackoff:
     """Retry behavior for transient scraper failures.
 
@@ -1165,10 +1018,7 @@ class TestRetryBackoff:
     Sleep is patched out class-wide so the suite stays fast.
     """
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_429_then_200_succeeds(
         self,
         mock_get,
@@ -1192,10 +1042,7 @@ class TestRetryBackoff:
             assert mock_get.call_count == 2
             assert mock_sleep.call_count == 1
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_all_429s_exhaust_attempts_no_cache(
         self,
         mock_get,
@@ -1208,24 +1055,17 @@ class TestRetryBackoff:
         from shuffify.models.db import ScrapedPlaylistCache
 
         with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=429, text="", headers={}
-            )
+            mock_get.return_value = Mock(status_code=429, text="", headers={})
             pathway = PublicScraperPathway()
             result = pathway.resolve(mock_source)
 
             assert result.success is False
             # MAX_ATTEMPTS per pathway, two pathways tried.
             assert mock_get.call_count == 6
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is None
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_403_short_circuits_no_retry(
         self,
         mock_get,
@@ -1240,9 +1080,7 @@ class TestRetryBackoff:
         from shuffify.models.db import ScrapedPlaylistCache
 
         with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=403, text="", headers={}
-            )
+            mock_get.return_value = Mock(status_code=403, text="", headers={})
             pathway = PublicScraperPathway()
             result = pathway.resolve(mock_source)
 
@@ -1250,15 +1088,10 @@ class TestRetryBackoff:
             # One attempt per pathway, no retry sleeps.
             assert mock_get.call_count == 2
             assert mock_sleep.call_count == 0
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
+            row = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").first()
             assert row is None
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_timeout_then_200_succeeds(
         self,
         mock_get,
@@ -1283,10 +1116,7 @@ class TestRetryBackoff:
             assert mock_get.call_count == 2
             assert mock_sleep.call_count == 1
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_200_zero_retries(
         self,
         mock_get,
@@ -1298,9 +1128,7 @@ class TestRetryBackoff:
         and zero sleeps. Retry logic must not add overhead to the
         common case."""
         with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=200, text=LEGACY_URL_HTML
-            )
+            mock_get.return_value = Mock(status_code=200, text=LEGACY_URL_HTML)
             pathway = PublicScraperPathway()
             result = pathway.resolve(mock_source)
 
@@ -1308,10 +1136,7 @@ class TestRetryBackoff:
             assert mock_get.call_count == 1
             assert mock_sleep.call_count == 0
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_retry_after_header_honored(
         self,
         mock_get,
@@ -1370,19 +1195,12 @@ class TestRequestTimeoutConfig:
             db_app.config["SOURCE_RESOLVER_TIMEOUT"] = 25
             assert _get_request_timeout() == 25
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_scrape_passes_configured_timeout(
-        self, mock_get, mock_source, db_app
-    ):
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
+    def test_scrape_passes_configured_timeout(self, mock_get, mock_source, db_app):
         """The configured timeout flows through to ``requests.get``."""
         with db_app.app_context():
             db_app.config["SOURCE_RESOLVER_TIMEOUT"] = 7
-            mock_get.return_value = Mock(
-                status_code=200, text="<html></html>"
-            )
+            mock_get.return_value = Mock(status_code=200, text="<html></html>")
 
             pathway = PublicScraperPathway()
             pathway.resolve(mock_source)
@@ -1395,18 +1213,12 @@ class TestSleepWithBackoff:
     """Direct tests for the backoff helper. Patches ``time.sleep`` so
     we can verify the computed delay without actually waiting."""
 
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.time.sleep")
     @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.time.sleep"
-    )
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.random.uniform",
+        "shuffify.services.source_resolver.public_scraper_pathway.random.uniform",
         return_value=0.0,
     )
-    def test_exponential_backoff_doubles_per_attempt(
-        self, _mock_rand, mock_sleep
-    ):
+    def test_exponential_backoff_doubles_per_attempt(self, _mock_rand, mock_sleep):
         from shuffify.services.source_resolver.public_scraper_pathway import (
             _sleep_with_backoff,
             BACKOFF_BASE,
@@ -1423,18 +1235,12 @@ class TestSleepWithBackoff:
             BACKOFF_BASE * 4,
         ]
 
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.time.sleep")
     @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.time.sleep"
-    )
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.random.uniform",
+        "shuffify.services.source_resolver.public_scraper_pathway.random.uniform",
         return_value=0.0,
     )
-    def test_retry_after_overrides_exponential(
-        self, _mock_rand, mock_sleep
-    ):
+    def test_retry_after_overrides_exponential(self, _mock_rand, mock_sleep):
         from shuffify.services.source_resolver.public_scraper_pathway import (
             _sleep_with_backoff,
         )
@@ -1442,13 +1248,9 @@ class TestSleepWithBackoff:
         _sleep_with_backoff(0, retry_after="5")
         assert mock_sleep.call_args.args[0] == 5.0
 
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.time.sleep")
     @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.time.sleep"
-    )
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.random.uniform",
+        "shuffify.services.source_resolver.public_scraper_pathway.random.uniform",
         return_value=0.0,
     )
     def test_unparseable_retry_after_falls_back_to_exponential(
@@ -1462,18 +1264,12 @@ class TestSleepWithBackoff:
         _sleep_with_backoff(1, retry_after="soon")
         assert mock_sleep.call_args.args[0] == BACKOFF_BASE * 2
 
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.time.sleep")
     @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.time.sleep"
-    )
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.random.uniform",
+        "shuffify.services.source_resolver.public_scraper_pathway.random.uniform",
         return_value=0.0,
     )
-    def test_max_backoff_caps_long_waits(
-        self, _mock_rand, mock_sleep
-    ):
+    def test_max_backoff_caps_long_waits(self, _mock_rand, mock_sleep):
         from shuffify.services.source_resolver.public_scraper_pathway import (
             _sleep_with_backoff,
             MAX_BACKOFF,
@@ -1517,10 +1313,7 @@ class TestScraperFailureModes:
             ),
             '<script>{"trackList": 42}</script>',  # wrong type
             '<script>{"trackList": null}</script>',
-            (
-                '<script id="__NEXT_DATA__" type="application/json">'
-                'null</script>'
-            ),
+            ('<script id="__NEXT_DATA__" type="application/json">null</script>'),
             "\x00\x01\x02 binary junk \xff",
         ]
         for html in garbage_inputs:
@@ -1546,9 +1339,7 @@ class TestScraperFailureModes:
 
     # -- Cache TTL boundary --------------------------------------------
 
-    def test_cache_hit_just_under_ttl_returns_cached(
-        self, mock_source, db_app
-    ):
+    def test_cache_hit_just_under_ttl_returns_cached(self, mock_source, db_app):
         """A cache row whose ``expires_at`` is still in the future
         (even by one second) must be served from cache without an
         HTTP call. Pairs with the existing
@@ -1556,7 +1347,8 @@ class TestScraperFailureModes:
         boundary on both sides."""
         from datetime import datetime, timedelta, timezone
         from shuffify.models.db import (
-            ScrapedPlaylistCache, db,
+            ScrapedPlaylistCache,
+            db,
         )
 
         with db_app.app_context():
@@ -1575,8 +1367,7 @@ class TestScraperFailureModes:
             db.session.commit()
 
             with patch(
-                "shuffify.services.source_resolver"
-                ".public_scraper_pathway.requests.get"
+                "shuffify.services.source_resolver.public_scraper_pathway.requests.get"
             ) as mock_get:
                 pathway = PublicScraperPathway()
                 result = pathway.resolve(mock_source)
@@ -1590,10 +1381,7 @@ class TestScraperFailureModes:
 
     # -- Concurrent cache write idempotency ----------------------------
 
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
+    @patch("shuffify.services.source_resolver.public_scraper_pathway.requests.get")
     def test_set_cached_is_idempotent_for_same_playlist(
         self, mock_get, mock_source, db_app
     ):
@@ -1618,9 +1406,7 @@ class TestScraperFailureModes:
                 pathway="public_page",
             )
 
-            rows = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).all()
+            rows = ScrapedPlaylistCache.query.filter_by(playlist_id="pl_test123").all()
             assert len(rows) == 1
             assert rows[0].scrape_pathway == "public_page"
             assert rows[0].track_uris == [
@@ -1630,29 +1416,31 @@ class TestScraperFailureModes:
 
     # -- Commit-failure rollback (L2) ----------------------------------
 
-    def test_set_cached_rolls_back_on_commit_failure(
-        self, db_app
-    ):
+    def test_set_cached_rolls_back_on_commit_failure(self, db_app):
         """If ``db.session.commit`` raises, ``_set_cached`` must
         catch the exception, roll back, and leave the session in
         a state that subsequent operations can use. Without the
         rollback, SQLAlchemy holds the failed transaction and
         every later query raises ``PendingRollbackError``."""
         from shuffify.models.db import (
-            ScrapedPlaylistCache, db,
+            ScrapedPlaylistCache,
+            db,
         )
 
         with db_app.app_context():
             real_commit = db.session.commit
-            with patch.object(
-                db.session,
-                "commit",
-                side_effect=Exception("boom"),
-            ) as mock_commit, patch.object(
-                db.session,
-                "rollback",
-                wraps=db.session.rollback,
-            ) as mock_rollback:
+            with (
+                patch.object(
+                    db.session,
+                    "commit",
+                    side_effect=Exception("boom"),
+                ) as mock_commit,
+                patch.object(
+                    db.session,
+                    "rollback",
+                    wraps=db.session.rollback,
+                ) as mock_rollback,
+            ):
                 PublicScraperPathway._set_cached(
                     "pl_test123",
                     ["spotify:track:aaaaaaaaaaaaaaaaaaaaaa"],
@@ -1670,44 +1458,4 @@ class TestScraperFailureModes:
                 ["spotify:track:dddddddddddddddddddddd"],
                 pathway="embed",
             )
-            assert (
-                ScrapedPlaylistCache.query.count()
-                == count_before + 1
-            )
-
-    # -- L1: track_count is no longer written for new rows -------------
-
-    @patch(
-        "shuffify.services.source_resolver"
-        ".public_scraper_pathway.requests.get"
-    )
-    def test_set_cached_does_not_write_track_count(
-        self, mock_get, mock_source, db_app
-    ):
-        """``track_count`` is dead — no reader anywhere — so the
-        scraper no longer populates it. The column defaults to 0
-        at the schema level, which is all callers can observe.
-
-        Pinning this lets a future cleanup PR safely drop the column
-        via Alembic without surprising anyone."""
-        from shuffify.models.db import ScrapedPlaylistCache
-
-        with db_app.app_context():
-            mock_get.return_value = Mock(
-                status_code=200,
-                text=NEXT_DATA_TRACKS_ITEMS_HTML,
-            )
-
-            pathway = PublicScraperPathway()
-            result = pathway.resolve(mock_source)
-            assert result.success is True
-
-            row = ScrapedPlaylistCache.query.filter_by(
-                playlist_id="pl_test123"
-            ).first()
-            assert row is not None
-            # Column defaults to 0 since the constructor no
-            # longer sets it. The actual count lives on
-            # ``len(row.track_uris)``.
-            assert row.track_count == 0
-            assert len(row.track_uris) == 3
+            assert ScrapedPlaylistCache.query.count() == count_before + 1

--- a/tests/services/test_job_executor_rotate.py
+++ b/tests/services/test_job_executor_rotate.py
@@ -60,7 +60,8 @@ def _make_tracks(uris):
 
 
 def _make_api(
-    prod_tracks=None, archive_tracks=None,
+    prod_tracks=None,
+    archive_tracks=None,
     post_removal_prod=None,
 ):
     """Create a stateful mock SpotifyAPI.
@@ -83,14 +84,8 @@ def _make_api(
     api = MagicMock()
 
     state = {
-        "target1": [
-            t["uri"] for t in (prod_tracks or [])
-            if t.get("uri")
-        ],
-        "archive1": [
-            t["uri"] for t in (archive_tracks or [])
-            if t.get("uri")
-        ],
+        "target1": [t["uri"] for t in (prod_tracks or []) if t.get("uri")],
+        "archive1": [t["uri"] for t in (archive_tracks or []) if t.get("uri")],
     }
 
     target_fetch_count = {"n": 0}
@@ -99,18 +94,14 @@ def _make_api(
     def get_tracks(playlist_id, skip_cache=False):
         if playlist_id == "target1":
             target_fetch_count["n"] += 1
-            if (
-                forced_post is not None
-                and target_fetch_count["n"] >= 2
-            ):
+            if forced_post is not None and target_fetch_count["n"] >= 2:
                 return list(forced_post)
-        return [
-            {"uri": u, "name": u}
-            for u in state.get(playlist_id, [])
-        ]
+        return [{"uri": u, "name": u} for u in state.get(playlist_id, [])]
 
     def add_items(
-        playlist_id, uris, position=None,
+        playlist_id,
+        uris,
+        position=None,
     ):
         if playlist_id not in state:
             state[playlist_id] = []
@@ -126,20 +117,13 @@ def _make_api(
     def remove_items(playlist_id, uris):
         to_remove = set(uris)
         state[playlist_id] = [
-            u for u in state.get(playlist_id, [])
-            if u not in to_remove
+            u for u in state.get(playlist_id, []) if u not in to_remove
         ]
         return True
 
-    api.get_playlist_tracks = MagicMock(
-        side_effect=get_tracks
-    )
-    api.playlist_remove_items = MagicMock(
-        side_effect=remove_items
-    )
-    api.playlist_add_items = MagicMock(
-        side_effect=add_items
-    )
+    api.get_playlist_tracks = MagicMock(side_effect=get_tracks)
+    api.playlist_remove_items = MagicMock(side_effect=remove_items)
+    api.playlist_add_items = MagicMock(side_effect=add_items)
     api._state = state
     return api
 
@@ -159,25 +143,15 @@ def _make_pair():
 class TestExecuteRotateSwap:
     """Tests for swap rotation mode."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_swap_exchanges_tracks(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_swap_exchanges_tracks(self, mock_random, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2", "a3"])
@@ -191,47 +165,29 @@ class TestExecuteRotateSwap:
         )
         # random.sample returns first N for
         # deterministic testing
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
 
         assert result["tracks_added"] == 2
         assert result["tracks_total"] == 3
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_swap_uses_fifo_order(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_swap_uses_fifo_order(self, mock_random, mock_pair, mock_snap):
         """Swap-in selects oldest archived tracks first
         (FIFO), not most recently added (LIFO)."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         # Archive order: old1 is oldest, old3 is newest
-        archive = _make_tracks(
-            ["old1", "old2", "old3"]
-        )
-        post_prod = _make_tracks(
-            ["p3", "old1", "old2"]
-        )
+        archive = _make_tracks(["old1", "old2", "old3"])
+        post_prod = _make_tracks(["p3", "old1", "old2"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -241,52 +197,33 @@ class TestExecuteRotateSwap:
             rotation_count=2,
             target_size=3,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         execute_rotate(schedule, api)
 
         # Verify swap-in used first 2 (oldest), not
         # last 2 (newest)
         add_calls = api.playlist_add_items.call_args_list
-        swap_in_call = [
-            c for c in add_calls
-            if c[0][0] == "target1"
-        ]
+        swap_in_call = [c for c in add_calls if c[0][0] == "target1"]
         assert len(swap_in_call) == 1
         added_uris = swap_in_call[0][0][1]
         assert added_uris == ["old1", "old2"]
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_swap_deduplicates(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_swap_deduplicates(self, mock_random, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
-        prod = _make_tracks(
-            ["p1", "p2", "shared"]
-        )
+        prod = _make_tracks(["p1", "p2", "shared"])
         # "shared" is in both — will be purged from
         # archive by _purge_archive_overlaps
         archive = _make_tracks(["shared", "a1"])
-        post_prod = _make_tracks(
-            ["p2", "shared", "a1"]
-        )
+        post_prod = _make_tracks(["p2", "shared", "a1"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -296,33 +233,22 @@ class TestExecuteRotateSwap:
             rotation_count=3,
             target_size=3,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
 
         # "shared" purged from archive; only a1
         # available to swap in; swap limited to 1
         assert result["tracks_added"] == 1
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_swap_empty_archive(
-        self, mock_pair, mock_snap
-    ):
+    def test_swap_empty_archive(self, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2"])
         post_prod = _make_tracks(["p1", "p2"])
@@ -336,53 +262,35 @@ class TestExecuteRotateSwap:
             target_size=2,
         )
 
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
 
         assert result["tracks_added"] == 0
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_empty_playlist_returns_zero(
-        self, mock_pair, mock_snap
-    ):
+    def test_empty_playlist_returns_zero(self, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         api = _make_api(prod_tracks=[])
         schedule = _make_schedule()
 
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
 
         assert result["tracks_added"] == 0
         assert result["tracks_total"] == 0
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_auto_snapshot_created(
-        self, mock_pair, mock_snap
-    ):
+    def test_auto_snapshot_created(self, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            True
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = True
 
         prod = _make_tracks(["u1", "u2", "u3"])
         api = _make_api(
@@ -394,27 +302,18 @@ class TestExecuteRotateSwap:
             target_size=3,
         )
 
-        execute_rotate(
-            schedule, api
-        )
+        execute_rotate(schedule, api)
 
         mock_snap.create_snapshot.assert_called_once()
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_snapshot_skipped_when_disabled(
-        self, mock_pair, mock_snap
-    ):
+    def test_snapshot_skipped_when_disabled(self, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["u1", "u2", "u3"])
         api = _make_api(
@@ -426,9 +325,7 @@ class TestExecuteRotateSwap:
             target_size=3,
         )
 
-        execute_rotate(
-            schedule, api
-        )
+        execute_rotate(schedule, api)
 
         mock_snap.create_snapshot.assert_not_called()
 
@@ -446,9 +343,7 @@ class TestExecuteRotateSwap:
             JobExecutionError,
             match="No archive pair found",
         ):
-            execute_rotate(
-                schedule, api
-            )
+            execute_rotate(schedule, api)
 
 
 # =============================================================================
@@ -459,38 +354,26 @@ class TestExecuteRotateSwap:
 class TestSwapDedup:
     """Swap must not push duplicates to archive."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
+    @patch("shuffify.services.executors.rotate_executor.random")
     def test_swap_skips_outgoing_already_in_archive(
         self, mock_random, mock_pair, mock_snap
     ):
         """If a prod track being swapped out is already in
         the archive, don't add it again."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
-        prod = _make_tracks(
-            ["p1", "p2", "p3", "p4"]
-        )
+        prod = _make_tracks(["p1", "p2", "p3", "p4"])
         # p1 is in both — will be purged from archive
         # by _purge_archive_overlaps. Archive after
         # purge: [a1, a2]
         archive = _make_tracks(["p1", "a1", "a2"])
-        post_prod = _make_tracks(
-            ["p3", "p4", "a1", "a2"]
-        )
+        post_prod = _make_tracks(["p3", "p4", "a1", "a2"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -500,9 +383,7 @@ class TestSwapDedup:
             rotation_count=2,
             target_size=4,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
@@ -511,36 +392,23 @@ class TestSwapDedup:
         # p1, p2 swapped out; neither is in the
         # cleaned archive so both added to archive
         add_calls = api.playlist_add_items.call_args_list
-        archive_add = [
-            c for c in add_calls
-            if c[0][0] == "archive1"
-        ]
+        archive_add = [c for c in add_calls if c[0][0] == "archive1"]
         assert len(archive_add) == 1
-        assert set(archive_add[0][0][1]) == {
-            "p1", "p2"
-        }
+        assert set(archive_add[0][0][1]) == {"p1", "p2"}
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
+    @patch("shuffify.services.executors.rotate_executor.random")
     def test_swap_all_outgoing_already_in_archive(
         self, mock_random, mock_pair, mock_snap
     ):
         """If all outgoing tracks are already in the
         archive, skip the archive add entirely."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         # p1 is in both — purged from archive.
@@ -556,9 +424,7 @@ class TestSwapDedup:
             rotation_count=1,
             target_size=3,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
@@ -567,10 +433,7 @@ class TestSwapDedup:
         # p1 is NOT in cleaned archive (was purged),
         # so it IS added to archive
         add_calls = api.playlist_add_items.call_args_list
-        archive_add = [
-            c for c in add_calls
-            if c[0][0] == "archive1"
-        ]
+        archive_add = [c for c in add_calls if c[0][0] == "archive1"]
         assert len(archive_add) == 1
         assert archive_add[0][0][1] == ["p1"]
 
@@ -583,26 +446,16 @@ class TestSwapDedup:
 class TestSwapOverflow:
     """Tests for Phase 1 overflow archival."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_overflow_archives_excess(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_overflow_archives_excess(self, mock_random, mock_pair, mock_snap):
         """When playlist exceeds cap, archive excess."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
@@ -616,9 +469,7 @@ class TestSwapOverflow:
             rotation_count=2,
             target_size=5,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
@@ -645,15 +496,16 @@ class TestPurgeArchiveOverlaps:
         prod_set = {"shared1", "shared2", "p1"}
 
         cleaned, purged = _purge_archive_overlaps(
-            api, "archive1", archive_uris, prod_set,
+            api,
+            "archive1",
+            archive_uris,
+            prod_set,
         )
 
         assert purged == 2
         assert cleaned == ["a1"]
         api.playlist_remove_items.assert_called_once()
-        removed = (
-            api.playlist_remove_items.call_args[0][1]
-        )
+        removed = api.playlist_remove_items.call_args[0][1]
         assert set(removed) == {"shared1", "shared2"}
 
     def test_no_overlaps_no_removal(self):
@@ -663,7 +515,10 @@ class TestPurgeArchiveOverlaps:
         prod_set = {"p1", "p2"}
 
         cleaned, purged = _purge_archive_overlaps(
-            api, "archive1", archive_uris, prod_set,
+            api,
+            "archive1",
+            archive_uris,
+            prod_set,
         )
 
         assert purged == 0
@@ -679,7 +534,10 @@ class TestPurgeArchiveOverlaps:
         prod_set = {"p1", "p2", "p3"}
 
         cleaned, purged = _purge_archive_overlaps(
-            api, "archive1", archive_uris, prod_set,
+            api,
+            "archive1",
+            archive_uris,
+            prod_set,
         )
 
         assert purged == 2
@@ -689,7 +547,10 @@ class TestPurgeArchiveOverlaps:
         """Empty archive has nothing to purge."""
         api = MagicMock()
         cleaned, purged = _purge_archive_overlaps(
-            api, "archive1", [], {"p1"},
+            api,
+            "archive1",
+            [],
+            {"p1"},
         )
 
         assert purged == 0
@@ -706,34 +567,20 @@ class TestRandomSelection:
     """Tests that swap-out and overflow use random
     selection."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_swap_out_uses_random_sample(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_swap_out_uses_random_sample(self, mock_random, mock_pair, mock_snap):
         """Phase 2 swap-out uses random.sample."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
-        prod = _make_tracks(
-            ["p1", "p2", "p3", "p4", "p5"]
-        )
+        prod = _make_tracks(["p1", "p2", "p3", "p4", "p5"])
         archive = _make_tracks(["a1", "a2"])
-        post_prod = _make_tracks(
-            ["p1", "p2", "p3", "a1", "a2"]
-        )
+        post_prod = _make_tracks(["p1", "p2", "p3", "a1", "a2"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -744,9 +591,7 @@ class TestRandomSelection:
             target_size=5,
         )
         # Return last 2 instead of first 2
-        mock_random.sample.return_value = [
-            "p4", "p5"
-        ]
+        mock_random.sample.return_value = ["p4", "p5"]
 
         result = execute_rotate(schedule, api)
 
@@ -757,32 +602,20 @@ class TestRandomSelection:
         sample_args = mock_random.sample.call_args
         assert sample_args[0][1] == 2
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_overflow_uses_random_sample(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_overflow_uses_random_sample(self, mock_random, mock_pair, mock_snap):
         """Phase 1 overflow uses random.sample."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
-        post_prod = _make_tracks(
-            ["u0", "u1", "u2", "u4", "u6"]
-        )
+        post_prod = _make_tracks(["u0", "u1", "u2", "u4", "u6"])
         api = _make_api(
             prod_tracks=prod,
             post_removal_prod=post_prod,
@@ -792,9 +625,7 @@ class TestRandomSelection:
             target_size=5,
         )
         # Return random 3 from eligible
-        mock_random.sample.return_value = [
-            "u3", "u5", "u7"
-        ]
+        mock_random.sample.return_value = ["u3", "u5", "u7"]
 
         result = execute_rotate(schedule, api)
 
@@ -812,18 +643,12 @@ class TestRandomSelection:
 class TestVerification:
     """Tests that tracks_total comes from re-fetch."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
+    @patch("shuffify.services.executors.rotate_executor.random")
     def test_overflow_raises_when_post_state_drifts(
         self, mock_random, mock_pair, mock_snap
     ):
@@ -834,9 +659,7 @@ class TestVerification:
         drifted count.)
         """
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
@@ -851,25 +674,17 @@ class TestVerification:
             rotation_count=2,
             target_size=5,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         with pytest.raises(PlaylistVerificationError):
             execute_rotate(schedule, api)
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
+    @patch("shuffify.services.executors.rotate_executor.random")
     def test_swap_raises_on_unexpected_extra_track(
         self, mock_random, mock_pair, mock_snap
     ):
@@ -879,15 +694,11 @@ class TestVerification:
         pre-F1 loose-verify test which accepted the drift.)
         """
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2"])
-        post_prod = _make_tracks(
-            ["p3", "a1", "a2", "extra"]
-        )
+        post_prod = _make_tracks(["p3", "a1", "a2", "extra"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -897,9 +708,7 @@ class TestVerification:
             rotation_count=2,
             target_size=3,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         with pytest.raises(PlaylistVerificationError):
             execute_rotate(schedule, api)
@@ -920,9 +729,7 @@ class TestExecuteRotateValidation:
     def test_invalid_mode_raises(self, mock_pair):
         mock_pair.return_value = _make_pair()
 
-        api = _make_api(
-            prod_tracks=_make_tracks(["u1"])
-        )
+        api = _make_api(prod_tracks=_make_tracks(["u1"]))
         schedule = _make_schedule()
         schedule.algorithm_params = {
             "rotation_mode": "invalid_mode",
@@ -933,29 +740,17 @@ class TestExecuteRotateValidation:
             JobExecutionError,
             match="Invalid rotation_mode",
         ):
-            execute_rotate(
-                schedule, api
-            )
+            execute_rotate(schedule, api)
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_missing_mode_defaults_to_swap(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_missing_mode_defaults_to_swap(self, mock_random, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["u1", "u2"])
         archive = _make_tracks(["a1", "a2"])
@@ -969,45 +764,27 @@ class TestExecuteRotateValidation:
         schedule.algorithm_params = {
             "target_size": 2,
         }
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
 
         # Defaults to swap with count=5, but only
         # 2 archive tracks available
         assert result["tracks_added"] == 2
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_count_defaults_to_5(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_count_defaults_to_5(self, mock_random, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
-        uris = [
-            "u{}".format(i) for i in range(10)
-        ]
+        uris = ["u{}".format(i) for i in range(10)]
         prod = _make_tracks(uris)
-        archive = _make_tracks(
-            ["a{}".format(i) for i in range(10)]
-        )
+        archive = _make_tracks(["a{}".format(i) for i in range(10)])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -1017,13 +794,9 @@ class TestExecuteRotateValidation:
             "rotation_mode": "swap",
             "target_size": 10,
         }
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
 
         # Default count=5, swaps 5 tracks
         assert result["tracks_added"] == 5
@@ -1032,14 +805,10 @@ class TestExecuteRotateValidation:
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_swap_without_target_size_raises(
-        self, mock_pair
-    ):
+    def test_swap_without_target_size_raises(self, mock_pair):
         mock_pair.return_value = _make_pair()
 
-        api = _make_api(
-            prod_tracks=_make_tracks(["u1", "u2"])
-        )
+        api = _make_api(prod_tracks=_make_tracks(["u1", "u2"]))
         schedule = _make_schedule()
         schedule.algorithm_params = {
             "rotation_mode": "swap",
@@ -1058,16 +827,11 @@ class TestExecuteRotateValidation:
         api = MagicMock()
 
         with patch(
-            "shuffify.services.executors.rotate_executor"
-            ".execute_rotate",
+            "shuffify.services.executors.rotate_executor.execute_rotate",
             return_value={"tracks_added": 0},
         ) as mock_rotate:
-            JobExecutorService._execute_job_type(
-                schedule, api
-            )
-            mock_rotate.assert_called_once_with(
-                schedule, api
-            )
+            JobExecutorService._execute_job_type(schedule, api)
+            mock_rotate.assert_called_once_with(schedule, api)
 
     def test_unknown_job_type_raises(self):
         """Unknown job type still raises error."""
@@ -1079,28 +843,17 @@ class TestExecuteRotateValidation:
             JobExecutionError,
             match="Unknown job type",
         ):
-            JobExecutorService._execute_job_type(
-                schedule, api
-            )
+            JobExecutorService._execute_job_type(schedule, api)
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_snapshot_failure_non_blocking(
-        self, mock_pair, mock_snap
-    ):
+    def test_snapshot_failure_non_blocking(self, mock_pair, mock_snap):
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            True
-        )
-        mock_snap.create_snapshot.side_effect = (
-            Exception("snap fail")
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = True
+        mock_snap.create_snapshot.side_effect = Exception("snap fail")
 
         prod = _make_tracks(["u1", "u2"])
         post_prod = _make_tracks(["u1", "u2"])
@@ -1114,9 +867,7 @@ class TestExecuteRotateValidation:
         )
 
         # Should not raise despite snapshot failure
-        result = execute_rotate(
-            schedule, api
-        )
+        result = execute_rotate(schedule, api)
         assert result["tracks_total"] == 2
 
 
@@ -1128,33 +879,19 @@ class TestExecuteRotateValidation:
 class TestProtectCount:
     """Tests for protect_count in swap rotation."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_swap_skips_protected(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_swap_skips_protected(self, mock_random, mock_pair, mock_snap):
         """Protected tracks are not swapped out."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
-        prod = _make_tracks(
-            ["p1", "p2", "p3", "p4", "p5"]
-        )
-        archive = _make_tracks(
-            ["a1", "a2", "a3"]
-        )
+        prod = _make_tracks(["p1", "p2", "p3", "p4", "p5"])
+        archive = _make_tracks(["a1", "a2", "a3"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -1164,9 +901,7 @@ class TestProtectCount:
             target_size=5,
         )
         schedule.algorithm_params["protect_count"] = 2
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
@@ -1174,23 +909,16 @@ class TestProtectCount:
         # and bring in a2, a3
         assert result["tracks_added"] == 2
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_protect_all_returns_zero_with_reason(
-        self, mock_pair, mock_snap
-    ):
+    def test_protect_all_returns_zero_with_reason(self, mock_pair, mock_snap):
         """If all tracks protected, nothing rotates and
         skipped_reason is set."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1"])
@@ -1210,9 +938,7 @@ class TestProtectCount:
 
         assert result["tracks_added"] == 0
         assert result["tracks_total"] == 3
-        assert result["skipped_reason"] == (
-            "all_tracks_protected"
-        )
+        assert result["skipped_reason"] == ("all_tracks_protected")
 
 
 # =============================================================================
@@ -1223,26 +949,16 @@ class TestProtectCount:
 class TestTargetSize:
     """Tests for target_size playlist cap."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_target_size_archives_overflow(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_target_size_archives_overflow(self, mock_random, mock_pair, mock_snap):
         """When over cap, excess tracks are archived."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         # 15 tracks, cap 5 => overflow = 10
         uris = ["u{}".format(i) for i in range(15)]
@@ -1256,9 +972,7 @@ class TestTargetSize:
             rotation_count=2,
             target_size=5,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
@@ -1266,33 +980,21 @@ class TestTargetSize:
         assert result["tracks_added"] == 0
         assert result["tracks_total"] == 5
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_target_size_under_cap_swaps(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_target_size_under_cap_swaps(self, mock_random, mock_pair, mock_snap):
         """Under cap, normal swap occurs."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         # 8 tracks, cap 10 => under cap
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
-        archive = _make_tracks(
-            ["a{}".format(i) for i in range(5)]
-        )
+        archive = _make_tracks(["a{}".format(i) for i in range(5)])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
@@ -1301,34 +1003,22 @@ class TestTargetSize:
             rotation_count=3,
             target_size=10,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
         assert result["tracks_added"] == 3
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_target_size_with_protect(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_target_size_with_protect(self, mock_random, mock_pair, mock_snap):
         """Cap + protect combined overflow."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         # 20 tracks, cap 10, protect 5
         # overflow = 20-10 = 10, eligible = 15
@@ -1344,9 +1034,7 @@ class TestTargetSize:
             target_size=10,
         )
         schedule.algorithm_params["protect_count"] = 5
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         result = execute_rotate(schedule, api)
 
@@ -1358,9 +1046,21 @@ class TestTargetSize:
         mock_random.sample.assert_called_once()
         sample_args = mock_random.sample.call_args
         assert sample_args[0][0] == [
-            "u5", "u6", "u7", "u8", "u9",
-            "u10", "u11", "u12", "u13", "u14",
-            "u15", "u16", "u17", "u18", "u19",
+            "u5",
+            "u6",
+            "u7",
+            "u8",
+            "u9",
+            "u10",
+            "u11",
+            "u12",
+            "u13",
+            "u14",
+            "u15",
+            "u16",
+            "u17",
+            "u18",
+            "u19",
         ]
         assert sample_args[0][1] == 10
 
@@ -1373,27 +1073,17 @@ class TestTargetSize:
 class TestOperationOrdering:
     """Verify remove-before-add ordering for resilience."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_overflow_removes_before_archiving(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_overflow_removes_before_archiving(self, mock_random, mock_pair, mock_snap):
         """Phase 1: remove from prod before adding to
         archive, so a failed remove leaves archive clean."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
@@ -1402,9 +1092,7 @@ class TestOperationOrdering:
             prod_tracks=prod,
             post_removal_prod=post_prod,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         # Track call order
         call_order = []
@@ -1414,28 +1102,22 @@ class TestOperationOrdering:
             call_order.append("remove")
             return orig_remove(*a, **k)
 
-        api.playlist_remove_items = MagicMock(
-            side_effect=track_remove
-        )
+        api.playlist_remove_items = MagicMock(side_effect=track_remove)
 
-        orig_batch = (
-            JobExecutorService._batch_add_tracks
-        )
+        orig_add = api.playlist_add_items
 
-        def track_add(*a, **k):
+        def track_add(pid, uris):
             call_order.append("add")
-            return orig_batch(*a, **k)
+            return orig_add(pid, uris)
+
+        api.playlist_add_items = MagicMock(side_effect=track_add)
 
         schedule = _make_schedule(
             rotation_count=2,
             target_size=5,
         )
 
-        with patch.object(
-            JobExecutorService, "_batch_add_tracks",
-            side_effect=track_add,
-        ):
-            execute_rotate(schedule, api)
+        execute_rotate(schedule, api)
 
         # First remove is the purge (no overlaps, so
         # no call), then overflow remove, then add
@@ -1446,56 +1128,39 @@ class TestOperationOrdering:
         first_add = call_order.index("add")
         assert first_remove < first_add
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
+    @patch("shuffify.services.executors.rotate_executor.random")
     def test_swap_removes_from_prod_before_archive_add(
         self, mock_random, mock_pair, mock_snap
     ):
         """Phase 2: remove from prod before adding to
         archive for outgoing tracks."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
-        prod = _make_tracks(
-            ["p1", "p2", "p3", "p4"]
-        )
+        prod = _make_tracks(["p1", "p2", "p3", "p4"])
         archive = _make_tracks(["a1", "a2"])
         api = _make_api(
             prod_tracks=prod,
             archive_tracks=archive,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         call_order = []
 
         def track_remove(pid, uris):
-            call_order.append(
-                ("remove", pid)
-            )
+            call_order.append(("remove", pid))
             return True
 
-        def track_add(api_obj, pid, uris):
-            call_order.append(
-                ("add", pid)
-            )
+        def track_add(pid, uris, position=None):
+            call_order.append(("add", pid))
 
-        api.playlist_remove_items.side_effect = (
-            track_remove
-        )
+        api.playlist_remove_items.side_effect = track_remove
+        api.playlist_add_items = MagicMock(side_effect=track_add)
 
         schedule = _make_schedule(
             rotation_count=2,
@@ -1506,12 +1171,8 @@ class TestOperationOrdering:
         # verify_playlist_state since the test's mocks
         # short-circuit the state mutation that verify
         # would otherwise see.
-        with patch.object(
-            JobExecutorService, "_batch_add_tracks",
-            side_effect=track_add,
-        ), patch(
-            "shuffify.services.executors.rotate_executor"
-            ".verify_playlist_state",
+        with patch(
+            "shuffify.services.executors.rotate_executor.verify_playlist_state",
             return_value=[],
         ):
             execute_rotate(schedule, api)
@@ -1519,13 +1180,11 @@ class TestOperationOrdering:
         # First op: remove from production (after
         # any purge remove calls)
         prod_remove_idx = next(
-            i for i, c in enumerate(call_order)
-            if c == ("remove", "target1")
+            i for i, c in enumerate(call_order) if c == ("remove", "target1")
         )
         # Archive add comes after prod remove
         archive_add_idx = next(
-            i for i, c in enumerate(call_order)
-            if c == ("add", "archive1")
+            i for i, c in enumerate(call_order) if c == ("add", "archive1")
         )
         assert prod_remove_idx < archive_add_idx
 
@@ -1545,7 +1204,11 @@ class TestCheckedRemove:
 
         # Should not raise
         _checked_remove(
-            api, "playlist1", ["u1"], 42, "test",
+            api,
+            "playlist1",
+            ["u1"],
+            42,
+            "test",
         )
 
     def test_falsy_return_raises(self):
@@ -1558,8 +1221,11 @@ class TestCheckedRemove:
             match="returned falsy",
         ):
             _checked_remove(
-                api, "playlist1", ["u1"],
-                42, "test phase",
+                api,
+                "playlist1",
+                ["u1"],
+                42,
+                "test phase",
             )
 
     def test_none_return_raises(self):
@@ -1572,31 +1238,24 @@ class TestCheckedRemove:
             match="returned falsy",
         ):
             _checked_remove(
-                api, "playlist1", ["u1"],
-                42, "test phase",
+                api,
+                "playlist1",
+                ["u1"],
+                42,
+                "test phase",
             )
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_swap_prod_remove_failure_aborts(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_swap_prod_remove_failure_aborts(self, mock_random, mock_pair, mock_snap):
         """If prod remove fails in swap, rotation
         aborts with JobExecutionError."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2"])
@@ -1609,16 +1268,12 @@ class TestCheckedRemove:
         # so _checked_remove raises. side_effect takes
         # precedence over return_value with the stateful
         # mock — override to return False.
-        api.playlist_remove_items.side_effect = (
-            lambda *a, **k: False
-        )
+        api.playlist_remove_items.side_effect = lambda *a, **k: False
         schedule = _make_schedule(
             rotation_count=2,
             target_size=3,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         with pytest.raises(
             JobExecutionError,
@@ -1626,43 +1281,29 @@ class TestCheckedRemove:
         ):
             execute_rotate(schedule, api)
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_overflow_remove_failure_aborts(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_overflow_remove_failure_aborts(self, mock_random, mock_pair, mock_snap):
         """If prod remove fails in overflow, rotation
         aborts with JobExecutionError."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         uris = ["u{}".format(i) for i in range(8)]
         prod = _make_tracks(uris)
         api = _make_api(prod_tracks=prod)
         # Purge has no overlaps so no call; overflow remove
         # returns falsy so _checked_remove raises.
-        api.playlist_remove_items.side_effect = (
-            lambda *a, **k: False
-        )
+        api.playlist_remove_items.side_effect = lambda *a, **k: False
         schedule = _make_schedule(
             rotation_count=2,
             target_size=5,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         with pytest.raises(
             JobExecutionError,
@@ -1670,27 +1311,17 @@ class TestCheckedRemove:
         ):
             execute_rotate(schedule, api)
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
-    def test_archive_remove_failure_aborts(
-        self, mock_random, mock_pair, mock_snap
-    ):
+    @patch("shuffify.services.executors.rotate_executor.random")
+    def test_archive_remove_failure_aborts(self, mock_random, mock_pair, mock_snap):
         """If archive remove fails in swap, rotation
         aborts."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2"])
@@ -1700,16 +1331,12 @@ class TestCheckedRemove:
         )
         # No overlaps so no purge call;
         # prod-remove succeeds, archive-remove fails
-        api.playlist_remove_items.side_effect = [
-            True, False
-        ]
+        api.playlist_remove_items.side_effect = [True, False]
         schedule = _make_schedule(
             rotation_count=2,
             target_size=3,
         )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         with pytest.raises(
             JobExecutionError,
@@ -1726,22 +1353,15 @@ class TestCheckedRemove:
 class TestTargetSizeGuard:
     """Tests for target_size floor check."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_target_size_zero_raises(
-        self, mock_pair, mock_snap
-    ):
+    def test_target_size_zero_raises(self, mock_pair, mock_snap):
         """target_size=0 raises JobExecutionError."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["u1", "u2"])
         api = _make_api(prod_tracks=prod)
@@ -1760,9 +1380,7 @@ class TestTargetSizeGuard:
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_target_size_none_raises(
-        self, mock_pair
-    ):
+    def test_target_size_none_raises(self, mock_pair):
         """target_size=None raises JobExecutionError."""
         mock_pair.return_value = _make_pair()
 
@@ -1789,23 +1407,16 @@ class TestTargetSizeGuard:
 class TestProtectCountWarning:
     """Tests for all-protected early return."""
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_all_protected_returns_skipped_reason(
-        self, mock_pair, mock_snap
-    ):
+    def test_all_protected_returns_skipped_reason(self, mock_pair, mock_snap):
         """When protect_count >= playlist size, result
         includes skipped_reason."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2"])
         api = _make_api(
@@ -1821,27 +1432,18 @@ class TestProtectCountWarning:
         result = execute_rotate(schedule, api)
 
         assert result["tracks_added"] == 0
-        assert result["skipped_reason"] == (
-            "all_tracks_protected"
-        )
+        assert result["skipped_reason"] == ("all_tracks_protected")
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_protect_equal_to_size_returns_reason(
-        self, mock_pair, mock_snap
-    ):
+    def test_protect_equal_to_size_returns_reason(self, mock_pair, mock_snap):
         """protect_count == len(prod_uris) triggers
         early return."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2", "p3"])
         api = _make_api(
@@ -1857,27 +1459,18 @@ class TestProtectCountWarning:
         result = execute_rotate(schedule, api)
 
         assert result["tracks_added"] == 0
-        assert result["skipped_reason"] == (
-            "all_tracks_protected"
-        )
+        assert result["skipped_reason"] == ("all_tracks_protected")
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_all_protected_no_remove_calls(
-        self, mock_pair, mock_snap
-    ):
+    def test_all_protected_no_remove_calls(self, mock_pair, mock_snap):
         """When all protected, no swap API calls
         are made."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "p2"])
         api = _make_api(
@@ -1909,34 +1502,34 @@ class TestPurgeArchiveErrorHandling:
         """SpotifyAPIError during purge raises
         JobExecutionError."""
         api = MagicMock()
-        api.playlist_remove_items.side_effect = (
-            SpotifyAPIError("API failed")
-        )
+        api.playlist_remove_items.side_effect = SpotifyAPIError("API failed")
 
         with pytest.raises(
             JobExecutionError,
             match="Failed to purge",
         ):
             _purge_archive_overlaps(
-                api, "archive1",
-                ["shared", "a1"], {"shared", "p1"},
+                api,
+                "archive1",
+                ["shared", "a1"],
+                {"shared", "p1"},
             )
 
     def test_not_found_raises_execution_error(self):
         """SpotifyNotFoundError during purge raises
         JobExecutionError."""
         api = MagicMock()
-        api.playlist_remove_items.side_effect = (
-            SpotifyNotFoundError("Not found")
-        )
+        api.playlist_remove_items.side_effect = SpotifyNotFoundError("Not found")
 
         with pytest.raises(
             JobExecutionError,
             match="Failed to purge",
         ):
             _purge_archive_overlaps(
-                api, "archive1",
-                ["shared"], {"shared"},
+                api,
+                "archive1",
+                ["shared"],
+                {"shared"},
             )
 
     def test_falsy_return_raises_execution_error(self):
@@ -1950,27 +1543,22 @@ class TestPurgeArchiveErrorHandling:
             match="Failed to purge",
         ):
             _purge_archive_overlaps(
-                api, "archive1",
-                ["shared"], {"shared"},
+                api,
+                "archive1",
+                ["shared"],
+                {"shared"},
             )
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    def test_purge_failure_aborts_rotation(
-        self, mock_pair, mock_snap
-    ):
+    def test_purge_failure_aborts_rotation(self, mock_pair, mock_snap):
         """Purge failure during full rotation aborts
         the entire operation."""
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
 
         prod = _make_tracks(["p1", "shared"])
         archive = _make_tracks(["shared", "a1"])
@@ -1978,9 +1566,7 @@ class TestPurgeArchiveErrorHandling:
             prod_tracks=prod,
             archive_tracks=archive,
         )
-        api.playlist_remove_items.side_effect = (
-            SpotifyAPIError("Purge failed")
-        )
+        api.playlist_remove_items.side_effect = SpotifyAPIError("Purge failed")
 
         schedule = _make_schedule(
             rotation_count=1,
@@ -2009,32 +1595,25 @@ class TestRotateStrictVerification:
     the executor wrote.
     """
 
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".PlaylistSnapshotService"
-    )
+    @patch("shuffify.services.executors.rotate_executor.PlaylistSnapshotService")
     @patch(
         "shuffify.services.playlist_pair_service"
         ".PlaylistPairService.get_pair_for_playlist"
     )
-    @patch(
-        "shuffify.services.executors.rotate_executor"
-        ".random"
-    )
+    @patch("shuffify.services.executors.rotate_executor.random")
     def test_swap_raises_when_post_state_drifts(
-        self, mock_random, mock_pair, mock_snap,
+        self,
+        mock_random,
+        mock_pair,
+        mock_snap,
     ):
         """If Spotify silently drops a track during the
         swap, the post-write fetch diverges from the
         executor's expected set and verification raises.
         """
         mock_pair.return_value = _make_pair()
-        mock_snap.is_auto_snapshot_enabled.return_value = (
-            False
-        )
-        mock_random.sample.side_effect = (
-            lambda lst, n: lst[:n]
-        )
+        mock_snap.is_auto_snapshot_enabled.return_value = False
+        mock_random.sample.side_effect = lambda lst, n: lst[:n]
 
         prod = _make_tracks(["p1", "p2", "p3"])
         archive = _make_tracks(["a1", "a2"])
@@ -2047,7 +1626,8 @@ class TestRotateStrictVerification:
             post_removal_prod=post_prod,
         )
         schedule = _make_schedule(
-            rotation_count=2, target_size=3,
+            rotation_count=2,
+            target_size=3,
         )
 
         with pytest.raises(PlaylistVerificationError):


### PR DESCRIPTION
## Summary

Six issues resolved in one branch:

- **#342** — Boundary validation for `PercentageShuffle` (`shuffle_percentage`, `shuffle_location`) and `ArtistSpacingShuffle` (`min_spacing`). Invalid inputs now raise `ValueError` before any shuffle logic runs.
- **#346** — Dead code removal: `TokenInfo._raw` field, `ScrapedPlaylistCache.track_count` column, rotation TODO stubs in `enums.py`, dead NOTE in `public_scraper_pathway.py`.
- **#347** — Extract functions in executors for readability: `_overflow_to_archive()`, `_execute_swap()`, `_restore_job_snapshots()`, `_persist_rollback_status()`. Also inlined the single-call `_batch_add_tracks` wrapper → direct `api.playlist_add_items()`.
- **#349** — Consolidate logout handler: merged duplicate `UserService.get_by_spotify_id()` calls into one try/except. Failures now logged via `logger.warning` instead of silently swallowed.
- **#350** — Spotify client fixes: search limit cap raised from 10→50 to match API maximum. Fixed retry/refresh budget overlap — token refresh now resets the attempt counter so the full retry budget is available post-refresh.
- **#356** — Overflow detection in `reassemble_with_locks()`: raises `ValueError` when shuffled URIs exceed available unlocked slots, preventing silent data loss.

Closes #342, #346, #347, #349, #350, #356

## Test plan

- [x] `flake8 shuffify/` — zero errors
- [x] `pytest tests/` — passing (test fixtures updated for model + API changes)
- [ ] Manual: confirm logout works end-to-end on staging
- [ ] Manual: confirm scheduled rotation jobs still execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)