### PR TITLE
fix: tech-debt config cleanup (7 issues)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,9 @@ SPOTIFY_CLIENT_ID=your_client_id_here
 SPOTIFY_CLIENT_SECRET=your_client_secret_here
 SPOTIFY_REDIRECT_URI=http://localhost:8000/callback
 
-# ─── Flask Configuration ──────────────────────────────────────
+# ─── App Configuration ───────────────────────────────────────
 # development or production (selects config class in config.py)
-FLASK_ENV=development
+APP_CONFIG=development
 # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=change-me-to-a-random-secret-key
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Replaced deprecated `FLASK_ENV` with `APP_CONFIG`** - Config selector env var renamed from `FLASK_ENV` (removed in Flask 3.0) to `APP_CONFIG` across app factory, run.py, Dockerfile, and .env.example. Closes #355
+- **`SESSION_COOKIE_SECURE` defaults to `True`** - Base Config now defaults secure cookies on; DevConfig and TestConfig explicitly override to `False`. Closes #355
+- **`migrations/env.py` guards `fileConfig` call** - Prevents crash when `config_file_name` is None (Flask-Migrate invocation path). Closes #355
+- **Dependency hygiene** - Moved `gunicorn` from base.txt to prod.txt (not needed in dev/test); moved CVE security pins (wheel, authlib, nltk, tornado) from dev.txt to base.txt so production inherits them. Closes #344
+
+### Removed
+- **Unused dependencies removed** - `python-jose`, `numpy`, and `marshmallow` stripped from requirements/base.txt (no imports found in codebase). Closes #343
+- **Hardcoded `SECRET_KEY` fallback removed from base Config** - `Config.SECRET_KEY` no longer defaults to `"a_default_secret_key_for_development"`. DevConfig auto-generates a random key; TestConfig uses an explicit test key; ProdConfig requires the env var (unchanged). Closes #341
+
+### Fixed
+- **`logging.basicConfig(level=DEBUG)` no longer runs at import time** - Moved into `create_app()` with level set to INFO in production, DEBUG otherwise. Prevents debug logging from polluting any process that imports the shuffify package. Closes #338
+- **`REDIS_URL` now fails loudly in production** - `_init_redis` raises `RuntimeError` if Redis is unavailable in production instead of silently falling back to filesystem sessions. Development still falls back gracefully. Closes #339
+
 ### Security
+- **X-Forwarded-For no longer trusted without proxy validation** - Added `werkzeug.middleware.proxy_fix.ProxyFix` with `x_for=1` to the WSGI app, replacing manual header parsing in `login_history_service.py`. Only one level of proxy is trusted, preventing IP spoofing via crafted headers. Closes #340
 - **CSRF protection on all state-changing endpoints** - Added Flask-WTF CSRFProtect to validate CSRF tokens on all POST/PUT/DELETE/PATCH requests, closing the CSRF vulnerability on 51 state-changing endpoints
   - Flask-WTF CSRFProtect initialized globally in the app factory
   - CSRF token exposed via `<meta name="csrf-token">` in `base.html`

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p .flask_session && \
 
 # Set environment variables
 ENV FLASK_APP=run.py
-ENV FLASK_ENV=production
+ENV APP_CONFIG=production
 
 # Expose port
 EXPOSE 8000

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import sys
 from dotenv import load_dotenv
 
@@ -48,7 +49,7 @@ def validate_required_env_vars(config_name=None):
 class Config:
     """Base configuration."""
 
-    SECRET_KEY = os.getenv("SECRET_KEY", "a_default_secret_key_for_development")
+    SECRET_KEY = os.environ.get("SECRET_KEY")
     SESSION_COOKIE_NAME = os.getenv("SESSION_COOKIE_NAME", "shuffify_session")
     SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
     SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
@@ -69,7 +70,7 @@ class Config:
     # Session security settings for OAuth
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = "Lax"  # More permissive for OAuth flows
-    SESSION_COOKIE_SECURE = False  # Set to True in production with HTTPS
+    SESSION_COOKIE_SECURE = True
 
     # Redis caching configuration for Spotify API responses
     CACHE_KEY_PREFIX = "shuffify:cache:"
@@ -116,7 +117,6 @@ class Config:
 class ProdConfig(Config):
     """Production configuration."""
 
-    # Note: FLASK_ENV was removed in Flask 3.0. Use config_name parameter instead.
     CONFIG_NAME = "production"
     SECRET_KEY = os.environ.get("SECRET_KEY")  # No fallback — validated on startup
     DEBUG = False
@@ -148,8 +148,8 @@ class ProdConfig(Config):
 class DevConfig(Config):
     """Development configuration."""
 
-    # Note: FLASK_ENV was removed in Flask 3.0. Use config_name parameter instead.
     CONFIG_NAME = "development"
+    SECRET_KEY = os.getenv("SECRET_KEY") or secrets.token_hex(32)
     DEBUG = True
     TESTING = True
     SESSION_COOKIE_SECURE = False
@@ -171,8 +171,10 @@ class TestConfig(Config):
     """
 
     CONFIG_NAME = "testing"
+    SECRET_KEY = "test-secret-key"
     TESTING = True
     WTF_CSRF_ENABLED = False
+    SESSION_COOKIE_SECURE = False
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     SCHEDULER_ENABLED = False
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -10,34 +10,34 @@ from alembic import context
 config = context.config
 
 # Interpret the config file for Python logging.
-# This line sets up loggers basically.
-fileConfig(config.config_file_name)
-logger = logging.getLogger('alembic.env')
+# config_file_name is None when invoked via Flask-Migrate.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+logger = logging.getLogger("alembic.env")
 
 
 def get_engine():
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
-        return current_app.extensions['migrate'].db.get_engine()
+        return current_app.extensions["migrate"].db.get_engine()
     except (TypeError, AttributeError):
         # this works with Flask-SQLAlchemy>=3
-        return current_app.extensions['migrate'].db.engine
+        return current_app.extensions["migrate"].db.engine
 
 
 def get_engine_url():
     try:
-        return get_engine().url.render_as_string(hide_password=False).replace(
-            '%', '%%')
+        return get_engine().url.render_as_string(hide_password=False).replace("%", "%%")
     except AttributeError:
-        return str(get_engine().url).replace('%', '%%')
+        return str(get_engine().url).replace("%", "%%")
 
 
 # add your model's MetaData object here
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-config.set_main_option('sqlalchemy.url', get_engine_url())
-target_db = current_app.extensions['migrate'].db
+config.set_main_option("sqlalchemy.url", get_engine_url())
+target_db = current_app.extensions["migrate"].db
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -46,7 +46,7 @@ target_db = current_app.extensions['migrate'].db
 
 
 def get_metadata():
-    if hasattr(target_db, 'metadatas'):
+    if hasattr(target_db, "metadatas"):
         return target_db.metadatas[None]
     return target_db.metadata
 
@@ -64,9 +64,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(
-        url=url, target_metadata=get_metadata(), literal_binds=True
-    )
+    context.configure(url=url, target_metadata=get_metadata(), literal_binds=True)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -84,13 +82,13 @@ def run_migrations_online():
     # when there are no changes to the schema
     # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
     def process_revision_directives(context, revision, directives):
-        if getattr(config.cmd_opts, 'autogenerate', False):
+        if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
             if script.upgrade_ops.is_empty():
                 directives[:] = []
-                logger.info('No changes in schema detected.')
+                logger.info("No changes in schema detected.")
 
-    conf_args = current_app.extensions['migrate'].configure_args
+    conf_args = current_app.extensions["migrate"].configure_args
     if conf_args.get("process_revision_directives") is None:
         conf_args["process_revision_directives"] = process_revision_directives
 
@@ -98,9 +96,7 @@ def run_migrations_online():
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection,
-            target_metadata=get_metadata(),
-            **conf_args
+            connection=connection, target_metadata=get_metadata(), **conf_args
         )
 
         with context.begin_transaction():

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,17 +2,15 @@ Flask>=3.1.3
 Flask-Session>=0.8.0
 Flask-WTF>=1.2.0
 python-dotenv==1.2.2
-gunicorn==26.0.0
-numpy>=2.4.4
 pydantic>=2.13.4
 requests==2.34.0
-python-jose>=3.5.0
 cryptography>=48.0.0
 redis>=7.4.0
 Flask-SQLAlchemy>=3.1.1
 Flask-Migrate>=4.1.0
 psycopg2-binary>=2.9.12
 APScheduler>=3.11.2
+Flask-Limiter>=4.1.1
 
 # --- Security: explicit floors for transitive deps with known CVEs ---
 # These packages are pulled in by Flask, requests, cryptography, etc.
@@ -22,6 +20,8 @@ urllib3>=2.7.0
 certifi>=2026.4.22
 MarkupSafe>=3.0.3
 PyYAML>=6.0.3
-marshmallow>=4.3.0,<5.0
 pyasn1>=0.6.3
-Flask-Limiter>=4.1.1
+wheel>=0.47.0
+authlib>=1.7.2
+nltk>=3.9.3
+tornado>=6.5.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,11 +21,3 @@ ipython==9.13.0
 
 # Observability (mirrors prod.txt so tests can patch sentry_sdk)
 sentry-sdk>=2.59.0,<3.0
-
-# Security: pin wheel to patched version (CVE-2026-24049)
-wheel>=0.47.0
-
-# Security: pin transitive deps with known CVEs
-authlib>=1.7.2       # CVE-2026-28802: JWT alg:none bypass
-nltk>=3.9.3          # CVE-2025-14009: zip extraction RCE
-tornado>=6.5.5         # CVE-2025-47287: multipart DoS

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
 # Production
+gunicorn==26.0.0
 sentry-sdk>=2.59.0,<3.0
 psycopg2>=2.9.9

--- a/run.py
+++ b/run.py
@@ -2,14 +2,12 @@ from shuffify import create_app
 import os
 
 # This file exists solely for gunicorn to have a WSGI entry point
-app = create_app(os.getenv('FLASK_ENV', 'development'))
+app = create_app(os.getenv("APP_CONFIG", "development"))
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(
-        host=os.getenv('FLASK_HOST', '0.0.0.0'),
-        port=int(os.getenv('FLASK_PORT', 8000)),
+        host=os.getenv("FLASK_HOST", "0.0.0.0"),
+        port=int(os.getenv("FLASK_PORT", 8000)),
         debug=app.debug,
-        use_reloader=os.getenv(
-            'FLASK_USE_RELOADER', 'true'
-        ).lower() == 'true',
+        use_reloader=os.getenv("FLASK_USE_RELOADER", "true").lower() == "true",
     )

--- a/shuffify/__init__.py
+++ b/shuffify/__init__.py
@@ -9,9 +9,9 @@ import redis
 from flask_limiter import Limiter
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
+from werkzeug.middleware.proxy_fix import ProxyFix
 from config import config, validate_required_env_vars
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 # Global Redis client for caching (initialized in create_app)
@@ -121,8 +121,10 @@ def is_db_available() -> bool:
 def _init_redis(app):
     """Configure Redis for session storage and caching.
 
-    Returns Redis client if available, None otherwise.
+    In production, raises RuntimeError if Redis is unavailable.
+    In development/testing, falls back to filesystem sessions.
     """
+    is_prod = app.config.get("CONFIG_NAME") == "production"
     redis_url = app.config.get("REDIS_URL")
     if redis_url:
         try:
@@ -136,11 +138,18 @@ def _init_redis(app):
             logger.info("Redis caching enabled")
             return client
         except redis.ConnectionError as e:
+            if is_prod:
+                raise RuntimeError(f"Redis connection failed in production: {e}") from e
             logger.warning(
                 "Redis connection failed: %s. Falling back to filesystem sessions.",
                 e,
             )
     else:
+        if is_prod:
+            raise RuntimeError(
+                "REDIS_URL must be set in production. "
+                "Filesystem sessions are not acceptable for production use."
+            )
         logger.warning("REDIS_URL not configured. Using filesystem sessions.")
 
     app.config["SESSION_TYPE"] = "filesystem"
@@ -420,11 +429,15 @@ def _apply_security_headers(app):
 def create_app(config_name=None):
     """Create and configure the Flask application."""
     if config_name is None:
-        config_name = os.getenv("FLASK_ENV", "production")
+        config_name = os.getenv("APP_CONFIG", "production")
 
     # Ensure config_name is a string
     if not isinstance(config_name, str):
         config_name = "production"  # Default to production if not a string
+
+    logging.basicConfig(
+        level=logging.DEBUG if config_name != "production" else logging.INFO
+    )
 
     logger.info("Creating app with config: %s", config_name)
 
@@ -447,6 +460,9 @@ def create_app(config_name=None):
 
     app = Flask(__name__)
     app.config.from_object(config[config_name])
+
+    # Trust one level of proxy so request.remote_addr reflects the real client IP.
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
     # Log important config values
     logger.info("SPOTIFY_REDIRECT_URI: %s", app.config.get("SPOTIFY_REDIRECT_URI"))

--- a/shuffify/services/login_history_service.py
+++ b/shuffify/services/login_history_service.py
@@ -58,14 +58,7 @@ class LoginHistoryService:
         Raises:
             LoginHistoryError: If recording fails.
         """
-        # Extract IP address, preferring X-Forwarded-For for proxied
-        # requests
-        ip_address = (
-            request.headers.get(
-                "X-Forwarded-For", ""
-            ).split(",")[0].strip()
-            or request.remote_addr
-        )
+        ip_address = request.remote_addr
 
         # Extract and truncate user agent to fit column length
         user_agent = request.headers.get("User-Agent", "")
@@ -81,8 +74,7 @@ class LoginHistoryService:
         )
         db.session.add(entry)
         safe_commit(
-            f"record login for user_id={user_id}, "
-            f"type={login_type}, ip={ip_address}",
+            f"record login for user_id={user_id}, type={login_type}, ip={ip_address}",
             LoginHistoryError,
         )
         return entry
@@ -111,9 +103,7 @@ class LoginHistoryService:
         Raises:
             LoginHistoryError: If the update fails.
         """
-        query = LoginHistory.query.filter_by(
-            user_id=user_id
-        ).filter(
+        query = LoginHistory.query.filter_by(user_id=user_id).filter(
             LoginHistory.logged_out_at.is_(None)
         )
 
@@ -121,9 +111,7 @@ class LoginHistoryService:
             query = query.filter_by(session_id=session_id)
 
         # Get the most recent open login record
-        entry = query.order_by(
-            LoginHistory.logged_in_at.desc()
-        ).first()
+        entry = query.order_by(LoginHistory.logged_in_at.desc()).first()
 
         if not entry:
             logger.debug(

--- a/tests/services/test_login_history_service.py
+++ b/tests/services/test_login_history_service.py
@@ -19,11 +19,13 @@ from shuffify.services.login_history_service import (
 def app_ctx(db_app):
     """Provide app context with a test user."""
     with db_app.app_context():
-        result = UserService.upsert_from_spotify({
-            "id": "user123",
-            "display_name": "Test User",
-            "images": [],
-        })
+        result = UserService.upsert_from_spotify(
+            {
+                "id": "user123",
+                "display_name": "Test User",
+                "images": [],
+            }
+        )
         yield result.user
 
 
@@ -37,9 +39,7 @@ def mock_request():
         "User-Agent": "Mozilla/5.0 TestBrowser",
     }
     req.headers = Mock()
-    req.headers.get = lambda key, default="": (
-        headers_data.get(key, default)
-    )
+    req.headers.get = lambda key, default="": headers_data.get(key, default)
     return req
 
 
@@ -53,18 +53,14 @@ def mock_request_with_proxy():
         "User-Agent": "Chrome/100",
     }
     req.headers = Mock()
-    req.headers.get = lambda key, default="": (
-        headers_data.get(key, default)
-    )
+    req.headers.get = lambda key, default="": headers_data.get(key, default)
     return req
 
 
 class TestRecordLogin:
     """Tests for record_login."""
 
-    def test_record_login_basic(
-        self, app_ctx, mock_request
-    ):
+    def test_record_login_basic(self, app_ctx, mock_request):
         """Should create a login history record."""
         entry = LoginHistoryService.record_login(
             user_id=app_ctx.id,
@@ -82,21 +78,19 @@ class TestRecordLogin:
         assert entry.logged_in_at is not None
         assert entry.logged_out_at is None
 
-    def test_record_login_uses_forwarded_ip(
-        self, app_ctx, mock_request_with_proxy
-    ):
-        """Should prefer X-Forwarded-For over remote_addr."""
+    def test_record_login_uses_remote_addr(self, app_ctx, mock_request_with_proxy):
+        """Should use remote_addr (ProxyFix corrects it at WSGI layer)."""
         entry = LoginHistoryService.record_login(
             user_id=app_ctx.id,
             request=mock_request_with_proxy,
             login_type="oauth_initial",
         )
 
-        assert entry.ip_address == "203.0.113.50"
+        # ProxyFix sets remote_addr from X-Forwarded-For at the
+        # WSGI layer, so the service reads remote_addr directly.
+        assert entry.ip_address == "10.0.0.1"
 
-    def test_record_login_falls_back_to_remote_addr(
-        self, app_ctx, mock_request
-    ):
+    def test_record_login_falls_back_to_remote_addr(self, app_ctx, mock_request):
         """Should use remote_addr when X-Forwarded-For is empty."""
         entry = LoginHistoryService.record_login(
             user_id=app_ctx.id,
@@ -106,9 +100,7 @@ class TestRecordLogin:
 
         assert entry.ip_address == "192.168.1.100"
 
-    def test_record_login_truncates_long_user_agent(
-        self, app_ctx
-    ):
+    def test_record_login_truncates_long_user_agent(self, app_ctx):
         """Should truncate user agent strings longer than 512."""
         req = Mock()
         req.remote_addr = "1.2.3.4"
@@ -127,9 +119,7 @@ class TestRecordLogin:
 
         assert len(entry.user_agent) == 512
 
-    def test_record_login_no_session_id(
-        self, app_ctx, mock_request
-    ):
+    def test_record_login_no_session_id(self, app_ctx, mock_request):
         """Should allow None session_id."""
         entry = LoginHistoryService.record_login(
             user_id=app_ctx.id,
@@ -139,9 +129,7 @@ class TestRecordLogin:
 
         assert entry.session_id is None
 
-    def test_record_login_different_types(
-        self, app_ctx, mock_request
-    ):
+    def test_record_login_different_types(self, app_ctx, mock_request):
         """Should record different login types."""
         for login_type in [
             "oauth_initial",
@@ -159,9 +147,7 @@ class TestRecordLogin:
 class TestRecordLogout:
     """Tests for record_logout."""
 
-    def test_record_logout_updates_most_recent(
-        self, app_ctx, mock_request
-    ):
+    def test_record_logout_updates_most_recent(self, app_ctx, mock_request):
         """Should set logged_out_at on the most recent open record."""
         entry = LoginHistoryService.record_login(
             user_id=app_ctx.id,
@@ -181,9 +167,7 @@ class TestRecordLogout:
         updated = db.session.get(LoginHistory, entry.id)
         assert updated.logged_out_at is not None
 
-    def test_record_logout_no_matching_record(
-        self, app_ctx
-    ):
+    def test_record_logout_no_matching_record(self, app_ctx):
         """Should return False when no open record exists."""
         result = LoginHistoryService.record_logout(
             user_id=app_ctx.id,
@@ -192,9 +176,7 @@ class TestRecordLogout:
 
         assert result is False
 
-    def test_record_logout_without_session_id(
-        self, app_ctx, mock_request
-    ):
+    def test_record_logout_without_session_id(self, app_ctx, mock_request):
         """Should match any open record when session_id is None."""
         LoginHistoryService.record_login(
             user_id=app_ctx.id,
@@ -208,9 +190,7 @@ class TestRecordLogout:
 
         assert result is True
 
-    def test_record_logout_only_updates_open_record(
-        self, app_ctx, mock_request
-    ):
+    def test_record_logout_only_updates_open_record(self, app_ctx, mock_request):
         """Should not re-update an already logged-out record."""
         # First login and logout
         LoginHistoryService.record_login(
@@ -231,9 +211,7 @@ class TestRecordLogout:
         )
         assert result is False
 
-    def test_record_logout_correct_session(
-        self, app_ctx, mock_request
-    ):
+    def test_record_logout_correct_session(self, app_ctx, mock_request):
         """Should only logout the matching session."""
         LoginHistoryService.record_login(
             user_id=app_ctx.id,

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -29,14 +29,14 @@ class TestCreateApp:
             assert app is not None
             assert app.config["DEBUG"] is True
 
-    def test_create_app_uses_flask_env_default(self):
-        """Should use FLASK_ENV when config_name not provided."""
+    def test_create_app_uses_app_config_default(self):
+        """Should use APP_CONFIG when config_name not provided."""
         with patch.dict(
             "os.environ",
             {
                 "SPOTIFY_CLIENT_ID": "test_id",
                 "SPOTIFY_CLIENT_SECRET": "test_secret",
-                "FLASK_ENV": "development",
+                "APP_CONFIG": "development",
                 "REDIS_URL": "",
             },
         ):
@@ -46,8 +46,11 @@ class TestCreateApp:
 
             assert app.config["DEBUG"] is True
 
-    def test_create_app_with_redis_url(self):
+    def test_create_app_with_redis_url(self, monkeypatch):
         """Should configure Redis session when REDIS_URL provided."""
+        from config import DevConfig
+
+        monkeypatch.setattr(DevConfig, "REDIS_URL", "redis://localhost:6379/0")
         mock_redis = MagicMock(spec=redis.Redis)
         mock_redis.ping.return_value = True
 
@@ -341,6 +344,94 @@ class TestSecretKeyValidation:
         # NOT the hardcoded 'a_default_secret_key_for_development'
         assert ProdConfig.SECRET_KEY != "a_default_secret_key_for_development"
 
+    def test_base_config_no_hardcoded_fallback(self):
+        """Base Config should not have a hardcoded SECRET_KEY fallback."""
+        from config import Config
+
+        assert Config.SECRET_KEY != "a_default_secret_key_for_development"
+
+    def test_dev_config_always_has_secret_key(self):
+        """DevConfig should auto-generate a SECRET_KEY if not in env."""
+        from config import DevConfig
+
+        assert DevConfig.SECRET_KEY is not None
+        assert len(DevConfig.SECRET_KEY) > 0
+
+    def test_test_config_has_explicit_secret_key(self):
+        """TestConfig should have an explicit SECRET_KEY."""
+        from config import TestConfig
+
+        assert TestConfig.SECRET_KEY == "test-secret-key"
+
+
+class TestRedisProductionRequirement:
+    """Tests for Redis requirement in production."""
+
+    def test_production_raises_without_redis_url(self):
+        """Production should fail loudly when REDIS_URL is not set."""
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "SECRET_KEY": "test-secret",
+                "REDIS_URL": "",
+            },
+        ):
+            from shuffify import create_app
+
+            with pytest.raises(RuntimeError, match="REDIS_URL must be set"):
+                create_app("production")
+
+    def test_production_raises_on_redis_connection_failure(self, monkeypatch):
+        """Production should fail loudly when Redis connection fails."""
+        from config import ProdConfig
+
+        monkeypatch.setattr(ProdConfig, "REDIS_URL", "redis://localhost:6379/0")
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "SECRET_KEY": "test-secret",
+                "REDIS_URL": "redis://localhost:6379/0",
+            },
+        ):
+            with patch("shuffify.redis.from_url") as mock_from_url:
+                mock_redis_client = Mock()
+                mock_redis_client.ping.side_effect = redis.ConnectionError(
+                    "Connection refused"
+                )
+                mock_from_url.return_value = mock_redis_client
+
+                from shuffify import create_app
+
+                with pytest.raises(RuntimeError, match="Redis connection failed"):
+                    create_app("production")
+
+    def test_development_falls_back_to_filesystem(self):
+        """Development should fall back to filesystem when Redis fails."""
+        with patch.dict(
+            "os.environ",
+            {
+                "SPOTIFY_CLIENT_ID": "test_id",
+                "SPOTIFY_CLIENT_SECRET": "test_secret",
+                "REDIS_URL": "redis://localhost:6379/0",
+            },
+        ):
+            with patch("shuffify.redis.from_url") as mock_from_url:
+                mock_redis_client = Mock()
+                mock_redis_client.ping.side_effect = redis.ConnectionError(
+                    "Connection refused"
+                )
+                mock_from_url.return_value = mock_redis_client
+
+                from shuffify import create_app
+
+                app = create_app("development")
+                assert app.config["SESSION_TYPE"] == "filesystem"
+
 
 class TestSecurityHeaders:
     """Tests for security response headers."""
@@ -385,12 +476,17 @@ class TestSecurityHeaders:
                 response = debug_client.get("/health")
                 assert "Strict-Transport-Security" not in response.headers
 
-    def test_hsts_present_in_production_mode(self):
+    def test_hsts_present_in_production_mode(self, monkeypatch):
         """HSTS should be sent when debug is False (production)."""
         import os
         from unittest.mock import patch
+        from config import ProdConfig
 
+        monkeypatch.setattr(ProdConfig, "REDIS_URL", "redis://localhost:6379/0")
         os.environ.pop("DATABASE_URL", None)
+
+        mock_redis = MagicMock(spec=redis.Redis)
+        mock_redis.ping.return_value = True
 
         with patch.dict(
             "os.environ",
@@ -399,20 +495,21 @@ class TestSecurityHeaders:
                 "SPOTIFY_CLIENT_SECRET": "test_secret",
                 "SPOTIFY_REDIRECT_URI": "http://localhost:5000/callback",
                 "SECRET_KEY": "test-secret-key-for-testing",
-                "REDIS_URL": "",
+                "REDIS_URL": "redis://localhost:6379/0",
             },
         ):
-            from shuffify import create_app
+            with patch("shuffify.redis.from_url", return_value=mock_redis):
+                from shuffify import create_app
 
-            app = create_app("production")
-            app.config["TESTING"] = True
+                app = create_app("production")
+                app.config["TESTING"] = True
 
-            with app.test_client() as prod_client:
-                response = prod_client.get("/health")
-                hsts = response.headers.get("Strict-Transport-Security")
-                assert hsts is not None
-                assert "max-age=31536000" in hsts
-                assert "includeSubDomains" in hsts
+                with app.test_client() as prod_client:
+                    response = prod_client.get("/health")
+                    hsts = response.headers.get("Strict-Transport-Security")
+                    assert hsts is not None
+                    assert "max-age=31536000" in hsts
+                    assert "includeSubDomains" in hsts
 
     def test_csp_header_present(self, client):
         """All responses should include Content-Security-Policy."""


### PR DESCRIPTION
## Summary

Seven config and dependency hygiene fixes bundled in one branch:

- **#338** — `logging.basicConfig(level=DEBUG)` moved from module import time into `create_app()`, level keyed to config (INFO in prod, DEBUG otherwise)
- **#339** — `_init_redis` now raises `RuntimeError` in production when Redis is unavailable instead of silently falling back to filesystem sessions
- **#340** — Added `werkzeug.middleware.proxy_fix.ProxyFix` with `x_for=1` to the WSGI app, replacing manual `X-Forwarded-For` parsing in `login_history_service.py`
- **#341** — Removed hardcoded `SECRET_KEY` fallback (`"a_default_secret_key_for_development"`) from base `Config`. DevConfig auto-generates via `secrets.token_hex(32)`, TestConfig uses explicit value
- **#343** — Removed unused dependencies: `python-jose`, `numpy`, `marshmallow` (no imports found in codebase)
- **#344** — Moved `gunicorn` from `base.txt` to `prod.txt`; moved CVE security pins (wheel, authlib, nltk, tornado) from `dev.txt` to `base.txt` so production inherits them
- **#355** — Replaced deprecated `FLASK_ENV` with `APP_CONFIG` across app factory, run.py, Dockerfile, .env.example; flipped `SESSION_COOKIE_SECURE` default to `True` (DevConfig/TestConfig override to `False`); guarded `fileConfig()` call in `migrations/env.py`

Ran `/simplify` — addressed review findings: removed `config_name` parameter from `_init_redis` (reads `CONFIG_NAME` from app.config instead), moved ProxyFix to top-level import, replaced try/finally config restoration in tests with `monkeypatch.setattr`.

Closes #338, #339, #340, #341, #343, #344, #355

## Test plan

- [x] Full test suite passes (1886 passed, 0 failed)
- [x] `flake8 shuffify/` clean
- [x] New tests for Redis production requirement (3 tests)
- [x] New tests for SECRET_KEY config changes (3 tests)
- [x] Updated test for APP_CONFIG env var rename
- [x] Updated login history test for ProxyFix behavior
- [ ] Verify `.env` files updated with `APP_CONFIG` instead of `FLASK_ENV`
- [ ] Verify Docker build picks up `APP_CONFIG=production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)