### PR TITLE
fix: logout handler — log swallowed exception, use cached user lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`search_playlists` total_tracks always returned 0** - Fixed wrong key lookup: the code tried `item["items"]` (which doesn't exist on playlist search results) before falling back to `item["tracks"]`. Simplified to use `item.get("tracks", {})` directly. Closes #335
+- **Logout handler: swallowed exception + redundant user lookup** - Token revocation failure now logs a warning instead of silently swallowing with bare `except: pass`. Replaced direct `UserService.get_by_spotify_id()` call with the session-cached `get_db_user()` helper. Closes #349
 - **`logging.basicConfig(level=DEBUG)` no longer runs at import time** - Moved into `create_app()` with level set to INFO in production, DEBUG otherwise. Prevents debug logging from polluting any process that imports the shuffify package. Closes #338
 - **`REDIS_URL` now fails loudly in production** - `_init_redis` raises `RuntimeError` if Redis is unavailable in production instead of silently falling back to filesystem sessions. Development still falls back gracefully. Closes #339
 - **Schedule.target_playlist_id column width** - Widened from String(64) to String(255) to match all other playlist ID columns. Alembic migration included. Closes #352

--- a/shuffify/routes/core.py
+++ b/shuffify/routes/core.py
@@ -347,27 +347,25 @@ def logout():
             access_token = token_data.get("access_token")
             if access_token:
                 AuthService.revoke_access_token(access_token)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Token revocation failed during logout: %s", e)
 
     # Record logout event and activity before clearing session
     try:
-        user_data = session.get("user_data")
-        if user_data and user_data.get("id"):
-            db_user = UserService.get_by_spotify_id(user_data["id"])
-            if db_user:
-                flask_session_id = getattr(session, "sid", None)
-                LoginHistoryService.record_logout(
-                    user_id=db_user.id,
-                    session_id=flask_session_id,
-                )
-                log_activity(
-                    user_id=db_user.id,
-                    activity_type=ActivityType.LOGOUT,
-                    description="Logged out",
-                )
+        db_user = get_db_user()
+        if db_user:
+            flask_session_id = getattr(session, "sid", None)
+            LoginHistoryService.record_logout(
+                user_id=db_user.id,
+                session_id=flask_session_id,
+            )
+            log_activity(
+                user_id=db_user.id,
+                activity_type=ActivityType.LOGOUT,
+                description="Logged out",
+            )
     except Exception as e:
-        logger.warning(f"Failed to record logout: {e}")
+        logger.warning("Failed to record logout: %s", e)
 
     session.clear()
     return redirect(url_for("main.index"))


### PR DESCRIPTION
## Summary
- Token revocation `except Exception: pass` now logs via `logger.warning()` — consistent with every other non-blocking failure in the codebase
- Replaced `UserService.get_by_spotify_id(user_data["id"])` with `get_db_user()`, which uses the session-cached PK for a faster lookup and avoids duplicating the string-key query
- Also switched the second `except` block from f-string to `%s`-style logging (avoids string formatting when the log level is suppressed)

Closes #349

## Test plan
- [ ] 9 logout-related tests pass (`pytest -k logout`)
- [ ] Full suite passes (1922 passed, pre-existing `test_search_clamps_limit_max` failure unrelated — tracked in #350)
- [ ] `flake8 shuffify/routes/core.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)