### PR TITLE
fix: align search limit test and docstring to Spotify's 50-item max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **`search_playlists` total_tracks always returned 0** - Fixed wrong key lookup: the code tried `item["items"]` (which doesn't exist on playlist search results) before falling back to `item["tracks"]`. Simplified to use `item.get("tracks", {})` directly. Closes #335
 - **Logout handler: swallowed exception + redundant user lookup** - Token revocation failure now logs a warning instead of silently swallowing with bare `except: pass`. Replaced direct `UserService.get_by_spotify_id()` call with the session-cached `get_db_user()` helper. Closes #349
+- **Search limit test and docstring aligned to 50** - `test_search_clamps_limit_max` expected clamping at 10 but code already clamps at 50 (Spotify's actual max). Updated test assertion and `SpotifyClient.search_playlists` docstring. Closes #350
 - **`logging.basicConfig(level=DEBUG)` no longer runs at import time** - Moved into `create_app()` with level set to INFO in production, DEBUG otherwise. Prevents debug logging from polluting any process that imports the shuffify package. Closes #338
 - **`REDIS_URL` now fails loudly in production** - `_init_redis` raises `RuntimeError` if Redis is unavailable in production instead of silently falling back to filesystem sessions. Development still falls back gracefully. Closes #339
 - **Schedule.target_playlist_id column width** - Widened from String(64) to String(255) to match all other playlist ID columns. Alembic migration included. Closes #352

--- a/shuffify/spotify/client.py
+++ b/shuffify/spotify/client.py
@@ -292,7 +292,7 @@ class SpotifyClient:
 
         Args:
             query: Search query string.
-            limit: Maximum number of results (1-10).
+            limit: Maximum number of results (1-50).
 
         Returns:
             List of playlist summary dictionaries.

--- a/tests/spotify/test_api_search.py
+++ b/tests/spotify/test_api_search.py
@@ -73,9 +73,7 @@ def sample_search_response():
                     "id": "playlist_abc",
                     "name": "Jazz Vibes",
                     "owner": {"display_name": "Spotify"},
-                    "images": [
-                        {"url": "https://example.com/jazz.jpg"}
-                    ],
+                    "images": [{"url": "https://example.com/jazz.jpg"}],
                     "tracks": {"total": 50},
                 },
                 {
@@ -117,10 +115,7 @@ class TestSearchPlaylists:
         assert results[0]["id"] == "playlist_abc"
         assert results[0]["name"] == "Jazz Vibes"
         assert results[0]["owner_display_name"] == "Spotify"
-        assert (
-            results[0]["image_url"]
-            == "https://example.com/jazz.jpg"
-        )
+        assert results[0]["image_url"] == "https://example.com/jazz.jpg"
         assert results[0]["total_tracks"] == 50
 
     def test_search_handles_missing_images(
@@ -133,9 +128,7 @@ class TestSearchPlaylists:
 
         assert results[1]["image_url"] is None
 
-    def test_search_handles_missing_owner(
-        self, api, mock_http, sample_search_response
-    ):
+    def test_search_handles_missing_owner(self, api, mock_http, sample_search_response):
         """Playlists with missing owner show 'Unknown'."""
         mock_http.get.return_value = sample_search_response
 
@@ -155,9 +148,7 @@ class TestSearchPlaylists:
 
     def test_search_empty_results(self, api, mock_http):
         """Empty search results should return empty list."""
-        mock_http.get.return_value = {
-            "playlists": {"items": []}
-        }
+        mock_http.get.return_value = {"playlists": {"items": []}}
 
         results = api.search_playlists("xyznonexistent")
 
@@ -171,9 +162,7 @@ class TestSearchPlaylists:
             },
         )
 
-    def test_search_skips_none_items(
-        self, api, mock_http
-    ):
+    def test_search_skips_none_items(self, api, mock_http):
         """None items in search results should be skipped."""
         mock_http.get.return_value = {
             "playlists": {
@@ -198,9 +187,7 @@ class TestSearchPlaylists:
 
     def test_search_respects_limit(self, api, mock_http):
         """Limit parameter should be passed to API."""
-        mock_http.get.return_value = {
-            "playlists": {"items": []}
-        }
+        mock_http.get.return_value = {"playlists": {"items": []}}
 
         api.search_playlists("test", limit=5)
 
@@ -213,13 +200,9 @@ class TestSearchPlaylists:
             },
         )
 
-    def test_search_clamps_limit_min(
-        self, api, mock_http
-    ):
+    def test_search_clamps_limit_min(self, api, mock_http):
         """Limit below 1 should be clamped to 1."""
-        mock_http.get.return_value = {
-            "playlists": {"items": []}
-        }
+        mock_http.get.return_value = {"playlists": {"items": []}}
 
         api.search_playlists("test", limit=0)
 
@@ -232,13 +215,9 @@ class TestSearchPlaylists:
             },
         )
 
-    def test_search_clamps_limit_max(
-        self, api, mock_http
-    ):
-        """Limit above 10 should be clamped to 10."""
-        mock_http.get.return_value = {
-            "playlists": {"items": []}
-        }
+    def test_search_clamps_limit_max(self, api, mock_http):
+        """Limit above 50 should be clamped to 50."""
+        mock_http.get.return_value = {"playlists": {"items": []}}
 
         api.search_playlists("test", limit=100)
 
@@ -247,17 +226,13 @@ class TestSearchPlaylists:
             params={
                 "q": "test",
                 "type": "playlist",
-                "limit": 10,
+                "limit": 50,
             },
         )
 
-    def test_search_calls_http_client(
-        self, api, mock_http
-    ):
+    def test_search_calls_http_client(self, api, mock_http):
         """Search should call HTTP client with params."""
-        mock_http.get.return_value = {
-            "playlists": {"items": []}
-        }
+        mock_http.get.return_value = {"playlists": {"items": []}}
 
         api.search_playlists("my query", limit=10)
 
@@ -274,35 +249,27 @@ class TestSearchPlaylists:
 class TestSearchPlaylistsWithCache:
     """Tests for search_playlists caching behavior."""
 
-    def test_search_returns_cached_results(
-        self, valid_token, auth_manager, mock_http
-    ):
+    def test_search_returns_cached_results(self, valid_token, auth_manager, mock_http):
         """Cached results should be returned without API."""
         import redis as redis_lib
 
         mock_redis = Mock(spec=redis_lib.Redis)
         cache = SpotifyCache(mock_redis)
 
-        mock_redis.get.return_value = (
-            b'[{"id": "cached", "name": "Cached Playlist"}]'
-        )
+        mock_redis.get.return_value = b'[{"id": "cached", "name": "Cached Playlist"}]'
 
         with patch(
             "shuffify.spotify.api.SpotifyHTTPClient",
             return_value=mock_http,
         ):
-            api = SpotifyAPI(
-                valid_token, auth_manager, cache=cache
-            )
+            api = SpotifyAPI(valid_token, auth_manager, cache=cache)
             results = api.search_playlists("jazz")
 
         assert len(results) == 1
         assert results[0]["id"] == "cached"
         mock_http.get.assert_not_called()
 
-    def test_search_skip_cache(
-        self, valid_token, auth_manager, mock_http
-    ):
+    def test_search_skip_cache(self, valid_token, auth_manager, mock_http):
         """skip_cache=True should bypass cache."""
         import redis as redis_lib
 
@@ -328,12 +295,8 @@ class TestSearchPlaylistsWithCache:
             "shuffify.spotify.api.SpotifyHTTPClient",
             return_value=mock_http,
         ):
-            api = SpotifyAPI(
-                valid_token, auth_manager, cache=cache
-            )
-            results = api.search_playlists(
-                "jazz", skip_cache=True
-            )
+            api = SpotifyAPI(valid_token, auth_manager, cache=cache)
+            results = api.search_playlists("jazz", skip_cache=True)
 
         assert results[0]["id"] == "fresh"
         mock_http.get.assert_called_once()


### PR DESCRIPTION
## Summary
- `test_search_clamps_limit_max` expected clamping at 10 but the implementation already clamps at 50 (Spotify's actual max) — updated test assertion and docstring
- Fixed `SpotifyClient.search_playlists` docstring from "1-10" to "1-50"
- The retry/refresh budget overlap was also already fixed in a prior commit (while-loop with `attempt = 0` reset)

Closes #350

## Test plan
- [ ] All 1923 tests pass (0 failures — this PR fixes the only pre-existing failure)
- [ ] `flake8 shuffify/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)