### PR TITLE
security: run container as non-root + HSTS preload (#395, #401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Container runs as non-root** - Added `USER nobody` to the Dockerfile so gunicorn no longer runs as root in the production container (`.flask_session` is already chowned to `nobody:nogroup`, and gunicorn binds a non-privileged port). Closes #395
+- **HSTS `preload` directive** - Added `preload` to the production `Strict-Transport-Security` header (now `max-age=31536000; includeSubDomains; preload`). Closes #401
+
 ### Added
 - **Per-playlist execution lock** - New `shuffify.services.playlist_lock.playlist_lock` context manager serializes `JobExecutorService.execute()` runs that target the same playlist, using Postgres session-level advisory locks on a dedicated pool connection. Prevents the race where two schedules sharing a cron firing time on the same playlist interleave reads and writes (e.g. a shuffle's post-write verification reading mid-flight rotate state and failing with `expected N tracks, got N-K`). No-op on SQLite (dev/test, single-process). Lock acquisition has a 60-second timeout; on timeout the run is skipped with a `WARNING` log and the next cron fire retries.
 - **docker-compose source mount fix** - Moved host source mount (`-v .:/app`) from `docker-compose.yml` into new `docker-compose.override.yml` (auto-loaded in dev, skipped in prod). `docker-compose.prod.yml` adds `restart: unless-stopped`. Closes #345

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,10 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:8000/health || exit 1
 
+# Drop root privileges: run the app as the non-root 'nobody' user.
+# The .flask_session dir above is chowned to nobody:nogroup so the filesystem
+# session fallback stays writable; gunicorn binds :8000 (>1024, no root needed).
+USER nobody
+
 # Run the application
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--preload", "run:app"]

--- a/shuffify/__init__.py
+++ b/shuffify/__init__.py
@@ -403,7 +403,7 @@ def _apply_security_headers(app):
         # HSTS: only in production (development uses HTTP)
         if not app.debug:
             response.headers["Strict-Transport-Security"] = (
-                "max-age=31536000; includeSubDomains"
+                "max-age=31536000; includeSubDomains; preload"
             )
 
         # No-cache headers for development mode

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -516,6 +516,7 @@ class TestSecurityHeaders:
                     assert hsts is not None
                     assert "max-age=31536000" in hsts
                     assert "includeSubDomains" in hsts
+                    assert "preload" in hsts
 
     def test_csp_header_present(self, client):
         """All responses should include Content-Security-Policy."""


### PR DESCRIPTION
## Summary
Two production deployment-hardening fixes from the security-wave triage on shuffify. Both verified genuinely-open on `main` (not already remediated).

## Changes
- **#395 — Container ran as root.** The Dockerfile chowns `.flask_session` to `nobody:nogroup` but never issued a `USER` directive, so gunicorn ran as **root**. Added `USER nobody` before `CMD`. Safe to drop privileges: gunicorn binds non-privileged `:8000`, prod sessions/DB are Redis/Postgres, and the session-fallback dir is already owned by `nobody`. (Also makes the CLAUDE.md "runs as `nobody:nogroup`" claim actually true.)
- **#401 — HSTS missing `preload`.** Appended `preload` to the production `Strict-Transport-Security` header → `max-age=31536000; includeSubDomains; preload`.

## Verification
- `flake8 shuffify/` — clean
- `black --check` — clean
- `pytest tests/test_app_factory.py` — 42 passed; extended `test_hsts_present_in_production_mode` to assert `preload` is present.
- The Dockerfile `USER` change is container config (not covered by pytest) — verified by inspection.

## Note on HSTS `preload` (for the reviewer)
Adding `preload` advertises eligibility, but actually entering browser preload lists requires submitting the domain at https://hstspreload.org. `preload` is a **forward commitment** (hard to reverse once listed). The header itself is harmless; the submission decision is yours.

## Hold
Per the security-wave instruction: **DO NOT MERGE — held for Chris** (live-app security).

Closes #395
Closes #401
