### PR TITLE
fix(auth): make logout POST-only + CSRF-protected (SR-015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Logout is now POST-only and CSRF-protected** - `GET /logout` was a plain link that cleared the session and revoked the Spotify token — state-changing operations that `CSRFProtect` does not cover for GET requests, so any third-party page could force-logout every signed-in user with `<img src="…/logout">`. Logout is now `POST /logout` (GET returns 405), guarded by the app-wide CSRF token; the settings-sidebar link became a small CSRF-tokened form. Closes #453 (SR-015).
 - **Container runs as non-root** - Added `USER nobody` to the Dockerfile so gunicorn no longer runs as root in the production container (`.flask_session` is already chowned to `nobody:nogroup`, and gunicorn binds a non-privileged port). Closes #395
 - **HSTS `preload` directive** - Added `preload` to the production `Strict-Transport-Security` header (now `max-age=31536000; includeSubDomains; preload`). Closes #401
 - **Workshop track-URI XSS** - `track.uri` is now JS-escaped via Jinja `| tojson` in the lock/delete `onclick` handlers (single-quoted attribute), and the dynamically-rendered track rows wire their handlers through `addEventListener` + the element reference instead of interpolating the URI into an inline `onclick` string. Prevents stored XSS from track URIs originating in external/scraped playlist sources. Closes #267

--- a/shuffify/routes/core.py
+++ b/shuffify/routes/core.py
@@ -337,9 +337,14 @@ def callback():
         return redirect(url_for("main.index"))
 
 
-@main.route("/logout")
+@main.route("/logout", methods=["POST"])
 def logout():
-    """Clear session and log out."""
+    """Clear session and log out.
+
+    POST-only and CSRF-protected (via the app-wide CSRFProtect): logout is a
+    state-changing operation, so a GET link or cross-site `<img src>` must not
+    be able to force-logout users (SR-015).
+    """
     # Best-effort token revocation (fire-and-forget)
     try:
         token_data = session.get("spotify_token")

--- a/shuffify/templates/partials/settings_sidebar.html
+++ b/shuffify/templates/partials/settings_sidebar.html
@@ -115,11 +115,14 @@
                     class="w-full px-4 py-2 bg-white text-spotify-dark font-bold rounded-lg hover:bg-green-100 transition">
                 Save Settings
             </button>
-            <a href="{{ url_for('main.logout') }}"
-               onclick="return confirm('Are you sure you want to log out?')"
-               class="block w-full px-4 py-2 text-center text-red-300 hover:text-red-200 hover:bg-white/5 rounded-lg transition text-sm">
-                Log Out
-            </a>
+            <form method="POST" action="{{ url_for('main.logout') }}"
+                  onsubmit="return confirm('Are you sure you want to log out?')">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit"
+                        class="block w-full px-4 py-2 text-center text-red-300 hover:text-red-200 hover:bg-white/5 rounded-lg transition text-sm">
+                    Log Out
+                </button>
+            </form>
         </div>
 
     </div>

--- a/tests/routes/test_core_routes.py
+++ b/tests/routes/test_core_routes.py
@@ -325,24 +325,24 @@ class TestCallbackRoute:
 
 
 class TestLogoutRoute:
-    """Tests for GET /logout."""
+    """Tests for POST /logout (CSRF-guarded; GET rejected)."""
 
     def test_logout_clears_session_and_redirects(self, auth_client):
         """Logout should clear session and redirect to index."""
-        resp = auth_client.get("/logout")
+        resp = auth_client.post("/logout")
         assert resp.status_code == 302
         assert resp.headers["Location"].endswith("/")
 
     def test_logout_when_not_logged_in(self, db_app):
         """Logout without session should still work."""
         with db_app.test_client() as client:
-            resp = client.get("/logout")
+            resp = client.post("/logout")
             assert resp.status_code == 302
 
     @patch("shuffify.routes.core.AuthService")
     def test_logout_attempts_token_revocation(self, mock_auth_svc, auth_client):
         """Logout should call revoke_access_token with the session token."""
-        resp = auth_client.get("/logout")
+        resp = auth_client.post("/logout")
         assert resp.status_code == 302
         mock_auth_svc.revoke_access_token.assert_called_once_with("test_token")
 
@@ -354,9 +354,17 @@ class TestLogoutRoute:
     ):
         """Revocation failure must not block logout."""
         mock_auth_svc.revoke_access_token.side_effect = Exception("boom")
-        resp = auth_client.get("/logout")
+        resp = auth_client.post("/logout")
         assert resp.status_code == 302
         assert resp.headers["Location"].endswith("/")
+
+    def test_logout_get_is_rejected(self, auth_client):
+        """GET /logout must be rejected (405). Logout is a state-changing
+        operation, so it is POST-only and CSRF-guarded — a cross-site
+        `<img src=".../logout">` or link can no longer force-logout users
+        (SR-015)."""
+        resp = auth_client.get("/logout")
+        assert resp.status_code == 405
 
 
 class TestTermsRoute:


### PR DESCRIPTION
## Summary

Batch 6 — a contained **Workstream 5 (security)** fix. `GET /logout` cleared the session and revoked the Spotify token — state-changing operations that `CSRFProtect` doesn't cover for GET, so any third-party page could force-logout every signed-in user with `<img src="…/logout">`. Textbook login-CSRF vector.

## The fix

- Route → `methods=["POST"]` (GET now returns **405**); the app-wide `CSRFProtect(app)` guards the POST.
- Settings-sidebar link → a small CSRF-tokened `<form>` (`{{ csrf_token() }}`), preserving the confirm dialog and styling.

## Tests (TDD)

New `test_logout_get_is_rejected` (GET → 405, written first); the 4 existing logout tests updated GET → POST.

- `pytest tests/routes/test_core_routes.py::TestLogoutRoute` → 5 passed; flake8 clean. Full suite in CI.

Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)