### PR TITLE
fix: remove unconditional Development Mode banner leaking owner email (#481)

### DIFF
--- a/shuffify/templates/index.html
+++ b/shuffify/templates/index.html
@@ -2,13 +2,6 @@
 
 {% block content %}
 <div class="relative min-h-screen bg-dark-base">
-    <!-- Development Mode Notice — slim top bar -->
-    <div class="absolute top-0 left-0 right-0 z-10 bg-dark-surface/90 border-b border-amber-500/20 py-2 px-4 text-center">
-        <p class="text-amber-400/80 text-xs font-medium">
-            Development Mode — Contact <a href="mailto:christophertrogers37@gmail.com" class="underline hover:text-amber-300">christophertrogers37@gmail.com</a> for access
-        </p>
-    </div>
-
     <div class="absolute inset-0" style="background-image: url('/static/images/hero-pattern.svg'); opacity: 0.3; pointer-events: none;"></div>
     
     <!-- Hero Section — Two-Column Layout -->


### PR DESCRIPTION
Fixes #481.

## What

Deletes the unconditional "Development Mode" banner from `templates/index.html` — 7 lines, one file. It was hardcoded, never gated on config or environment, and published `christophertrogers37@gmail.com` to every visitor of `https://shuffify.app/`.

**Scope is deliberately narrow — banner only.** This does not touch the CSS/CSP issue tracked in #482 (separate cause, still waiting on a product decision between reverting the CSP tightening and doing a real Tailwind build). Diff is exactly one file, seven deletions, zero additions.

## Verification

Ari asked specifically that this be checked rather than assumed, since a trivial-looking delete is exactly where a wrapping div goes missing:

- **Nothing else depends on this block.** Grepped the whole repo for the banner's text ("Development Mode") and its specific CSS classes (`bg-dark-surface/90` + `border-amber-500/20` together) — only hits were the block itself. No test references this text or `index.html` at all before this PR.
- **The outer page wrapper is untouched.** Line 4 (`<div class="relative min-h-screen bg-dark-base">`) is the page's wrapping div and stays; only the self-contained inner notice div (comment + one complete `<div>...</div>`) is removed. Div-tag count in the file is balanced before and after (84 open / 84 close after the edit).
- **Rendered the real route, not a mock.** `create_app("testing")` + Flask's test client hitting `/` directly: `status: 200`, `Development Mode present: False`, `email present: False`, `hero section present: True` — the rest of the landing page renders exactly as before.
- **Full existing route suite passes.** `pytest tests/routes/test_core_routes.py` — 29 passed, 0 failed, including `test_unauthenticated_landing_has_shuffle_demo` and `test_unauthenticated_landing_has_two_column_hero`, which specifically cover this page's content.

## Deploy question — read before merging

This app is on DigitalOcean App Platform with `deploy_on_push: true` on the `main` branch. There is no separate "redeploy" step to run or skip — **merging this PR to `main` is itself what deploys it.** I have not merged it (I don't merge PRs), and I have not deployed anything separately. Once this is merged, I can confirm the live site (`https://shuffify.app/`) no longer serves the banner or the email — that check has to happen after merge, since there's nothing live to check yet.

## Not in this PR

The unstyled-site / CSP issue (#482) — separate cause, untouched here, still open on the fork Chris hasn't decided yet.
