### PR TITLE
chore: gitignore fleet bot telemetry droppings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,10 @@ test_notebook.ipynb
 # New additions
 .web-extension-id
 
+
+# Claude fleet bot telemetry — supervision hooks may write these relative to
+# the session cwd instead of the bot directory (Claudfather/Claudlobby#874);
+# they can land at any depth and are never product data.
+**/data/events/fleet-*.jsonl
+**/data/.last-tool-call
+**/data/.idle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Ignore Claude fleet bot telemetry paths** - Narrow any-depth `.gitignore` rules for `data/events/fleet-*.jsonl`, `data/.last-tool-call`, `data/.idle`: the files Claudlobby supervision hooks can write relative to the session cwd when the bot environment is absent (Claudfather/Claudlobby#874). Prevents a broad `git add` in an agent checkout from staging fleet telemetry into this public repo; product `data/` paths are unaffected.
 - **Logout is now POST-only and CSRF-protected** - `GET /logout` was a plain link that cleared the session and revoked the Spotify token — state-changing operations that `CSRFProtect` does not cover for GET requests, so any third-party page could force-logout every signed-in user with `<img src="…/logout">`. Logout is now `POST /logout` (GET returns 405), guarded by the app-wide CSRF token; the settings-sidebar link became a small CSRF-tokened form. Closes #453 (SR-015).
 - **Container runs as non-root** - Added `USER nobody` to the Dockerfile so gunicorn no longer runs as root in the production container (`.flask_session` is already chowned to `nobody:nogroup`, and gunicorn binds a non-privileged port). Closes #395
 - **HSTS `preload` directive** - Added `preload` to the production `Strict-Transport-Security` header (now `max-age=31536000; includeSubDomains; preload`). Closes #401


### PR DESCRIPTION
## Why

Claudlobby supervision hooks can write session telemetry relative to the session's working directory instead of the bot's own directory when the bot environment is absent from the hook env (Claudfather/Claudlobby#874). Fleet bots regularly run sessions inside checkouts of this repo, so untracked telemetry files accumulate in working trees — and one broad `git add -A` would commit fleet telemetry into a public repo. Observed landings include nested paths (`landing/data/events/` in one storydump checkout), so the rules match at any depth.

This is **defence-in-depth behind #874** (which fixes the writer), not the fix itself: with these rules, the checkout stays safe regardless of hook behavior.

## What

Three narrow ignore rules for the exact filenames the hooks write — deliberately not a directory-level `data/` ignore, so product data paths are unaffected. Plus a CHANGELOG entry.

## Verification

`git check-ignore -v` on root, nested, and dotfile probe paths — all four bind to the new rules:

```
.gitignore:79:**/data/events/fleet-*.jsonl	data/events/fleet-9999-01-01.jsonl
.gitignore:79:**/data/events/fleet-*.jsonl	sub/dir/data/events/fleet-9999-01-01.jsonl
.gitignore:80:**/data/.last-tool-call	data/.last-tool-call
.gitignore:81:**/data/.idle	sub/data/.idle
```

- `git ls-files -ci --exclude-standard` → **0** files (no previously-tracked file becomes ignored)
- Repo history scanned across all remote refs after a fresh `git fetch --prune`: **zero** telemetry files ever committed (`git log --remotes --diff-filter=ACR` over `*fleet-*.jsonl`, `*data/.last-tool-call`, `*data/.idle`)

Part of the fleet-wide telemetry-exposure sweep (task t-1785366988-c85c); one PR per affected repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RggBvjM8p4ngzR8xzDrTVr
