### PR TITLE
fix(raid): scope raid-source-count updates to the playlist in the URL (SR-038)

### DIFF
--- a/shuffify/routes/raid_panel.py
+++ b/shuffify/routes/raid_panel.py
@@ -281,7 +281,10 @@ def raid_source_count_update(
 
     try:
         source = UpstreamSourceService.update_raid_count(
-            user.id, req.source_id, req.raid_count
+            user.id,
+            playlist_id,
+            req.source_id,
+            req.raid_count,
         )
         return json_success(
             "Source raid count updated.",

--- a/shuffify/services/raid_sync_service.py
+++ b/shuffify/services/raid_sync_service.py
@@ -125,15 +125,17 @@ class RaidSyncService:
             SchedulerService,
         )
 
-        # Get source before deleting (need playlist_id)
+        # Get source before deleting (need playlist_id). Scoped to the target
+        # playlist as well as the owner: unwatching through a different
+        # playlist's route must not reach this source.
         source = UpstreamSourceService.get_source(
-            source_id, spotify_id
+            source_id, spotify_id, target_playlist_id
         )
         source_playlist_id = source.source_playlist_id
 
         # Delete the upstream source
         UpstreamSourceService.delete_source(
-            source_id, spotify_id
+            source_id, spotify_id, target_playlist_id
         )
 
         if user is None:

--- a/shuffify/services/upstream_source_service.py
+++ b/shuffify/services/upstream_source_service.py
@@ -305,16 +305,22 @@ class UpstreamSourceService:
     @staticmethod
     def update_raid_count(
         user_id: int,
+        target_playlist_id: str,
         source_id: int,
         raid_count: int,
     ) -> UpstreamSource:
         """Update a source's raid_count.
+
+        Scoped to the target playlist as well as the owner: a source is
+        configured against one playlist, so a request naming a different
+        playlist is not addressing this source.
 
         Raises UpstreamSourceNotFoundError if not found.
         """
         source = UpstreamSource.query.filter_by(
             id=source_id,
             user_id=user_id,
+            target_playlist_id=target_playlist_id,
         ).first()
         if not source:
             raise UpstreamSourceNotFoundError(

--- a/shuffify/services/upstream_source_service.py
+++ b/shuffify/services/upstream_source_service.py
@@ -248,7 +248,9 @@ class UpstreamSourceService:
 
     @staticmethod
     def get_source(
-        source_id: int, spotify_id: str
+        source_id: int,
+        spotify_id: str,
+        target_playlist_id: str = None,
     ) -> UpstreamSource:
         """
         Get a specific upstream source by ID.
@@ -256,26 +258,42 @@ class UpstreamSourceService:
         Args:
             source_id: The upstream source database ID.
             spotify_id: The Spotify user ID (for ownership check).
+            target_playlist_id: When given, the source must also be
+                configured against this playlist. Callers reached through a
+                ``/playlist/<playlist_id>/`` route must pass it, so the
+                playlist in the URL constrains which source is addressed
+                rather than being decorative.
 
         Returns:
             UpstreamSource instance.
 
         Raises:
-            UpstreamSourceNotFoundError: If not found or not owned.
+            UpstreamSourceNotFoundError: If not found, not owned, or not
+                configured against ``target_playlist_id``.
         """
         user = get_user_or_raise(
             spotify_id, UpstreamSourceNotFoundError
         )
-        return get_owned_entity(
+        source = get_owned_entity(
             UpstreamSource,
             source_id,
             user.id,
             UpstreamSourceNotFoundError,
         )
+        if (
+            target_playlist_id is not None
+            and source.target_playlist_id != target_playlist_id
+        ):
+            raise UpstreamSourceNotFoundError(
+                f"Source {source_id} not found"
+            )
+        return source
 
     @staticmethod
     def delete_source(
-        source_id: int, spotify_id: str
+        source_id: int,
+        spotify_id: str,
+        target_playlist_id: str = None,
     ) -> bool:
         """
         Delete an upstream source configuration.
@@ -283,16 +301,19 @@ class UpstreamSourceService:
         Args:
             source_id: The upstream source database ID.
             spotify_id: The Spotify user ID (for ownership check).
+            target_playlist_id: When given, the source must also be
+                configured against this playlist.
 
         Returns:
             True if deleted successfully.
 
         Raises:
-            UpstreamSourceNotFoundError: If not found or not owned.
+            UpstreamSourceNotFoundError: If not found, not owned, or not
+                configured against ``target_playlist_id``.
             UpstreamSourceError: If deletion fails.
         """
         source = UpstreamSourceService.get_source(
-            source_id, spotify_id
+            source_id, spotify_id, target_playlist_id
         )
 
         db.session.delete(source)

--- a/tests/routes/test_raid_link_routes.py
+++ b/tests/routes/test_raid_link_routes.py
@@ -214,6 +214,47 @@ class TestRaidLinkSuccess:
         assert data["tracks_added"] == 3
 
 
+def _seed_source(db_app, spotify_id, target_playlist_id, raid_count=5):
+    """Create an upstream source owned by `spotify_id` on `target_playlist_id`."""
+    from shuffify.models.db import UpstreamSource, db
+    from shuffify.services.user_service import UserService
+
+    with db_app.app_context():
+        user = UserService.upsert_from_spotify(
+            {
+                "id": spotify_id,
+                "display_name": spotify_id,
+                "images": [],
+            }
+        ).user
+        source = UpstreamSource(
+            user_id=user.id,
+            target_playlist_id=target_playlist_id,
+            source_playlist_id=f"src-{target_playlist_id}",
+            source_type="external",
+            raid_count=raid_count,
+        )
+        db.session.add(source)
+        db.session.commit()
+        return source.id
+
+
+def _source_raid_count(db_app, source_id):
+    from shuffify.models.db import UpstreamSource, db
+
+    with db_app.app_context():
+        db.session.expire_all()
+        return UpstreamSource.query.get(source_id).raid_count
+
+
+def _source_exists(db_app, source_id):
+    from shuffify.models.db import UpstreamSource, db
+
+    with db_app.app_context():
+        db.session.expire_all()
+        return UpstreamSource.query.get(source_id) is not None
+
+
 class TestRaidSourceCountPlaylistScope:
     """A source belongs to one target playlist (SR-038).
 
@@ -225,44 +266,13 @@ class TestRaidSourceCountPlaylistScope:
     request was still being applied outside the scope it named.
     """
 
-    @staticmethod
-    def _seed(db_app, spotify_id, target_playlist_id, raid_count=5):
-        from shuffify.models.db import UpstreamSource, db
-        from shuffify.services.user_service import UserService
-
-        with db_app.app_context():
-            user = UserService.upsert_from_spotify(
-                {
-                    "id": spotify_id,
-                    "display_name": spotify_id,
-                    "images": [],
-                }
-            ).user
-            source = UpstreamSource(
-                user_id=user.id,
-                target_playlist_id=target_playlist_id,
-                source_playlist_id=f"src-{target_playlist_id}",
-                source_type="external",
-                raid_count=raid_count,
-            )
-            db.session.add(source)
-            db.session.commit()
-            return source.id
-
-    @staticmethod
-    def _raid_count(db_app, source_id):
-        from shuffify.models.db import UpstreamSource
-
-        with db_app.app_context():
-            return UpstreamSource.query.get(source_id).raid_count
-
     @patch("shuffify.routes.require_auth")
     def test_correct_playlist_still_updates(
         self, mock_auth, db_app, auth_client
     ):
         """The feature must keep working: right playlist, right source."""
         mock_auth.return_value = MagicMock()
-        source_id = self._seed(db_app, "user123", "playlist-A")
+        source_id = _seed_source(db_app, "user123", "playlist-A")
 
         resp = auth_client.put(
             "/playlist/playlist-A/raid-source-count",
@@ -270,7 +280,7 @@ class TestRaidSourceCountPlaylistScope:
         )
 
         assert resp.status_code == 200
-        assert self._raid_count(db_app, source_id) == 9
+        assert _source_raid_count(db_app, source_id) == 9
 
     @patch("shuffify.routes.require_auth")
     def test_other_playlist_cannot_update_the_source(
@@ -278,7 +288,7 @@ class TestRaidSourceCountPlaylistScope:
     ):
         """Playlist B's URL must not reach a source configured on playlist A."""
         mock_auth.return_value = MagicMock()
-        source_id = self._seed(db_app, "user123", "playlist-A")
+        source_id = _seed_source(db_app, "user123", "playlist-A")
 
         resp = auth_client.put(
             "/playlist/playlist-B/raid-source-count",
@@ -286,7 +296,7 @@ class TestRaidSourceCountPlaylistScope:
         )
 
         assert resp.status_code == 404
-        assert self._raid_count(db_app, source_id) == 5
+        assert _source_raid_count(db_app, source_id) == 5
 
     @patch("shuffify.routes.require_auth")
     def test_unowned_playlist_in_url_cannot_update_the_source(
@@ -294,7 +304,7 @@ class TestRaidSourceCountPlaylistScope:
     ):
         """The playlist in the path is not decorative."""
         mock_auth.return_value = MagicMock()
-        source_id = self._seed(db_app, "user123", "playlist-A")
+        source_id = _seed_source(db_app, "user123", "playlist-A")
 
         resp = auth_client.put(
             "/playlist/not-my-playlist/raid-source-count",
@@ -302,7 +312,7 @@ class TestRaidSourceCountPlaylistScope:
         )
 
         assert resp.status_code == 404
-        assert self._raid_count(db_app, source_id) == 5
+        assert _source_raid_count(db_app, source_id) == 5
 
     @patch("shuffify.routes.require_auth")
     def test_another_users_source_is_unreachable(
@@ -310,7 +320,7 @@ class TestRaidSourceCountPlaylistScope:
     ):
         """Owner scoping predates this fix; pin it so it cannot regress."""
         mock_auth.return_value = MagicMock()
-        victim_source_id = self._seed(db_app, "victim456", "playlist-A")
+        victim_source_id = _seed_source(db_app, "victim456", "playlist-A")
 
         resp = auth_client.put(
             "/playlist/playlist-A/raid-source-count",
@@ -318,4 +328,62 @@ class TestRaidSourceCountPlaylistScope:
         )
 
         assert resp.status_code == 404
-        assert self._raid_count(db_app, victim_source_id) == 5
+        assert _source_raid_count(db_app, victim_source_id) == 5
+
+
+class TestRaidUnwatchPlaylistScope:
+    """Same defect class as the raid-source-count scope, on unwatch.
+
+    unwatch resolved the source by owner alone, so the playlist in the URL was
+    decorative here too -- and this path DELETES. It also then updates the URL
+    playlist's raid schedule, so a mismatched call removed a source from one
+    playlist while editing another playlist's schedule.
+    """
+
+    @patch("shuffify.routes.require_auth")
+    def test_correct_playlist_still_unwatches(
+        self, mock_auth, db_app, auth_client
+    ):
+        """The feature must keep working."""
+        mock_auth.return_value = MagicMock()
+        source_id = _seed_source(db_app, "user123", "playlist-A")
+
+        resp = auth_client.post(
+            "/playlist/playlist-A/raid-unwatch",
+            json={"source_id": source_id},
+        )
+
+        assert resp.status_code == 200
+        assert _source_exists(db_app, source_id) is False
+
+    @patch("shuffify.routes.require_auth")
+    def test_other_playlist_cannot_delete_the_source(
+        self, mock_auth, db_app, auth_client
+    ):
+        """Playlist B's URL must not delete a source configured on A."""
+        mock_auth.return_value = MagicMock()
+        source_id = _seed_source(db_app, "user123", "playlist-A")
+
+        resp = auth_client.post(
+            "/playlist/playlist-B/raid-unwatch",
+            json={"source_id": source_id},
+        )
+
+        assert resp.status_code == 404
+        assert _source_exists(db_app, source_id) is True
+
+    @patch("shuffify.routes.require_auth")
+    def test_another_users_source_cannot_be_deleted(
+        self, mock_auth, db_app, auth_client
+    ):
+        """Owner scoping predates this fix; pin it so it cannot regress."""
+        mock_auth.return_value = MagicMock()
+        victim_source_id = _seed_source(db_app, "victim456", "playlist-A")
+
+        resp = auth_client.post(
+            "/playlist/playlist-A/raid-unwatch",
+            json={"source_id": victim_source_id},
+        )
+
+        assert resp.status_code == 404
+        assert _source_exists(db_app, victim_source_id) is True

--- a/tests/routes/test_raid_link_routes.py
+++ b/tests/routes/test_raid_link_routes.py
@@ -212,3 +212,110 @@ class TestRaidLinkSuccess:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["tracks_added"] == 3
+
+
+class TestRaidSourceCountPlaylistScope:
+    """A source belongs to one target playlist (SR-038).
+
+    The route took source_id from the body and the playlist from the path, but
+    only ever scoped the lookup by owner, so the playlist in the URL was
+    decorative: any of the caller's sources could be updated through any
+    playlist URL, including a playlist the caller does not own. Ownership was
+    always enforced, so this never reached another user's data -- but the
+    request was still being applied outside the scope it named.
+    """
+
+    @staticmethod
+    def _seed(db_app, spotify_id, target_playlist_id, raid_count=5):
+        from shuffify.models.db import UpstreamSource, db
+        from shuffify.services.user_service import UserService
+
+        with db_app.app_context():
+            user = UserService.upsert_from_spotify(
+                {
+                    "id": spotify_id,
+                    "display_name": spotify_id,
+                    "images": [],
+                }
+            ).user
+            source = UpstreamSource(
+                user_id=user.id,
+                target_playlist_id=target_playlist_id,
+                source_playlist_id=f"src-{target_playlist_id}",
+                source_type="external",
+                raid_count=raid_count,
+            )
+            db.session.add(source)
+            db.session.commit()
+            return source.id
+
+    @staticmethod
+    def _raid_count(db_app, source_id):
+        from shuffify.models.db import UpstreamSource
+
+        with db_app.app_context():
+            return UpstreamSource.query.get(source_id).raid_count
+
+    @patch("shuffify.routes.require_auth")
+    def test_correct_playlist_still_updates(
+        self, mock_auth, db_app, auth_client
+    ):
+        """The feature must keep working: right playlist, right source."""
+        mock_auth.return_value = MagicMock()
+        source_id = self._seed(db_app, "user123", "playlist-A")
+
+        resp = auth_client.put(
+            "/playlist/playlist-A/raid-source-count",
+            json={"source_id": source_id, "raid_count": 9},
+        )
+
+        assert resp.status_code == 200
+        assert self._raid_count(db_app, source_id) == 9
+
+    @patch("shuffify.routes.require_auth")
+    def test_other_playlist_cannot_update_the_source(
+        self, mock_auth, db_app, auth_client
+    ):
+        """Playlist B's URL must not reach a source configured on playlist A."""
+        mock_auth.return_value = MagicMock()
+        source_id = self._seed(db_app, "user123", "playlist-A")
+
+        resp = auth_client.put(
+            "/playlist/playlist-B/raid-source-count",
+            json={"source_id": source_id, "raid_count": 99},
+        )
+
+        assert resp.status_code == 404
+        assert self._raid_count(db_app, source_id) == 5
+
+    @patch("shuffify.routes.require_auth")
+    def test_unowned_playlist_in_url_cannot_update_the_source(
+        self, mock_auth, db_app, auth_client
+    ):
+        """The playlist in the path is not decorative."""
+        mock_auth.return_value = MagicMock()
+        source_id = self._seed(db_app, "user123", "playlist-A")
+
+        resp = auth_client.put(
+            "/playlist/not-my-playlist/raid-source-count",
+            json={"source_id": source_id, "raid_count": 77},
+        )
+
+        assert resp.status_code == 404
+        assert self._raid_count(db_app, source_id) == 5
+
+    @patch("shuffify.routes.require_auth")
+    def test_another_users_source_is_unreachable(
+        self, mock_auth, db_app, auth_client
+    ):
+        """Owner scoping predates this fix; pin it so it cannot regress."""
+        mock_auth.return_value = MagicMock()
+        victim_source_id = self._seed(db_app, "victim456", "playlist-A")
+
+        resp = auth_client.put(
+            "/playlist/playlist-A/raid-source-count",
+            json={"source_id": victim_source_id, "raid_count": 99},
+        )
+
+        assert resp.status_code == 404
+        assert self._raid_count(db_app, victim_source_id) == 5


### PR DESCRIPTION
## Why

`PUT /playlist/<playlist_id>/raid-source-count` took `source_id` from the body and `playlist_id` from the path, then looked the source up by owner alone:

```python
source = UpstreamSource.query.filter_by(id=source_id, user_id=user_id).first()
```

`playlist_id` was never used. A source is configured against exactly one target playlist, so the playlist in the URL was decorative — the request was applied outside the scope it named.

The sibling method in the same service already scopes this way. `update_track_count` filters on `user_id + target_playlist_id + source_playlist_id`; `update_raid_count` was the odd one out.

## Proving the door was open

Exercised against unmodified `main` (`0b702fc`) before writing the fix — a source seeded on `playlist-A`, then updated through a different playlist's URL:

| probe | before the fix | after the fix |
|---|---|---|
| `/playlist/playlist-B/raid-source-count` targeting playlist-A's source | **HTTP 200, raid_count 5 → 99** | HTTP 404, unchanged |
| `/playlist/not-my-playlist/raid-source-count` targeting own source | **HTTP 200, raid_count 5 → 77** | HTTP 404, unchanged |
| another user's source via the correct playlist | HTTP 404, unchanged | HTTP 404, unchanged |

Same probe, same seeds, both runs.

## On the severity label

The gap is real and the fix is right, but the third row is worth stating plainly, because it bounds the impact: **owner scoping was already enforced and this never reached another user's data.** `user_id` was always in the filter. The reachable effect is that a caller could update *their own* source through a playlist URL that doesn't own it — including a playlist ID they have no relationship with.

So this is an integrity/scope defect confined to the caller's own account, not a cross-tenant authorization bypass. P3 looks defensible on blast radius. It is still worth closing: the route accepted requests it should have rejected, and the missing filter is the kind of thing that becomes a real hole the moment some future caller reaches this service without an owner check. Flagging the distinction rather than restating the triage label, since the label drives how the rest of the cluster gets prioritised.

## What changed

Five lines. `update_raid_count` takes `target_playlist_id` and adds it to the filter; the route passes the `playlist_id` it already has. No new query, no behaviour change on the legitimate path.

## Verification

- **Four regression tests** added, covering both directions: the correct playlist still updates (positive control), another playlist cannot, an unowned playlist cannot, and another user's source stays unreachable.
- **Mutation check:** dropping the `target_playlist_id` filter fails exactly the two scope tests while the positive control and the cross-user test keep passing — so the tests bind to this fix rather than to the route being broken in general.
- `flake8 shuffify/` clean. `black --check` reports the same 53 files with and without this change — pre-existing tree-wide drift, and that CI step is `continue-on-error: true` pending the SR-037 ruff consolidation.

Closes SR-038 in #459.
