### PR TITLE
fix(drip): stop signalling a forced drip by mutating the raid link (SR-021)

### DIFF
--- a/shuffify/services/executors/base_executor.py
+++ b/shuffify/services/executors/base_executor.py
@@ -540,17 +540,23 @@ class JobExecutorService:
         record / rollback (#332, the SR-010 twin).
 
         Uses a *transient* Schedule (never persisted); the JobExecution is
-        recorded with a null ``schedule_id``. The caller must ensure drip is
-        enabled on the raid link.
+        recorded with a null ``schedule_id``.
+
+        A manual drip is forced: it runs regardless of the raid link's
+        ``drip_enabled`` setting. That intent travels in ``algorithm_params``
+        alongside ``drip_count`` rather than by pre-setting the flag on the
+        link, which would leave a pending ORM mutation that the next commit on
+        the session persists -- turning a one-off action into a stored setting.
         """
+        params = {"force": True}
+        if drip_count:
+            params["drip_count"] = drip_count
         schedule = Schedule(
             user_id=user_id,
             job_type=JobType.DRIP,
             target_playlist_id=target_playlist_id,
             target_playlist_name=(target_playlist_name or target_playlist_id),
-            algorithm_params=(
-                {"drip_count": drip_count} if drip_count else {}
-            ),
+            algorithm_params=params,
             is_enabled=True,
         )
         return JobExecutorService._run_job(schedule, None)

--- a/shuffify/services/executors/drip_executor.py
+++ b/shuffify/services/executors/drip_executor.py
@@ -53,7 +53,10 @@ def execute_drip(
             "first.".format(target_id)
         )
 
-    if not link.drip_enabled:
+    params = schedule.algorithm_params or {}
+
+    # A manual "Drip Now" runs regardless of the link's drip_enabled setting.
+    if not link.drip_enabled and not params.get("force"):
         logger.info(
             "Schedule %s: drip disabled for %s, "
             "skipping",
@@ -66,7 +69,6 @@ def execute_drip(
             "skipped_reason": "drip_disabled",
         }
 
-    params = schedule.algorithm_params or {}
     drip_count = params.get(
         "drip_count", link.drip_count
     )

--- a/shuffify/services/raid_sync_service.py
+++ b/shuffify/services/raid_sync_service.py
@@ -492,10 +492,8 @@ class RaidSyncService:
 
         # Inline drip (no schedule) — run through the executor safety rails
         # instead of a hand-rolled Schedule(id=0) that bypassed them (#332).
-        # A manual "Drip Now" forces the drip regardless of the schedule's
-        # drip_enabled flag; execute_drip re-reads the link, so enable it
-        # within this transaction before dispatching.
-        link.drip_enabled = True
+        # The forced-run intent is passed to the executor explicitly; it is not
+        # signalled by mutating the link.
         result = JobExecutorService.execute_drip_for_user(
             user_id=user.id,
             target_playlist_id=target_playlist_id,

--- a/tests/services/test_drip_now_no_side_effects.py
+++ b/tests/services/test_drip_now_no_side_effects.py
@@ -1,0 +1,164 @@
+"""A manual "Drip Now" must not become a stored setting.
+
+`drip_now()` used to pre-set `link.drip_enabled = True` in the session as an
+implicit parameter to `execute_drip`, which gates on that flag. The mutation
+was never explicitly committed -- but it sat pending on the shared session, and
+the drip path commits for unrelated reasons (`_mark_dripped_as_promoted`), so
+it rode along. One manual drip permanently enabled drip on the raid link.
+
+The forced-run intent now travels in `algorithm_params`, so the link is never
+touched. These pin both halves: the force still works, and the flag stays put.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def seeded(db_app):
+    from shuffify.models.db import RaidPlaylistLink, db
+    from shuffify.services.user_service import UserService
+
+    with db_app.app_context():
+        user = UserService.upsert_from_spotify(
+            {"id": "user123", "display_name": "u", "images": []}
+        ).user
+        db.session.add(
+            RaidPlaylistLink(
+                user_id=user.id,
+                target_playlist_id="target1",
+                target_playlist_name="Target",
+                raid_playlist_id="raid1",
+                raid_playlist_name="Raid",
+                drip_enabled=False,
+                drip_count=3,
+            )
+        )
+        db.session.commit()
+        return user.id
+
+
+def _stored_drip_enabled(db_app):
+    from shuffify.models.db import RaidPlaylistLink, db
+
+    with db_app.app_context():
+        db.session.expire_all()
+        return (
+            RaidPlaylistLink.query.filter_by(target_playlist_id="target1")
+            .first()
+            .drip_enabled
+        )
+
+
+class TestDripNowLeavesTheLinkAlone:
+    def test_inline_drip_does_not_enable_drip_on_the_link(
+        self, db_app, seeded
+    ):
+        """The regression: a one-off action must not persist a setting."""
+        from shuffify.services.raid_sync_service import RaidSyncService
+
+        from shuffify.services.base import safe_commit
+
+        def _executor_that_commits(**_kwargs):
+            # The real drip path commits the shared session for its own
+            # reasons (drip_executor._mark_dripped_as_promoted). A stand-in
+            # that skips the commit cannot observe a pending mutation riding
+            # along, so it would pass whether or not the bug is present.
+            safe_commit("mark dripped tracks as promoted")
+            return {"status": "success", "tracks_added": 1}
+
+        with db_app.app_context():
+            with patch(
+                "shuffify.services.executors.JobExecutorService."
+                "execute_drip_for_user",
+                side_effect=_executor_that_commits,
+            ):
+                RaidSyncService.drip_now("user123", "target1")
+
+        assert _stored_drip_enabled(db_app) is False
+
+    def test_pending_link_mutation_would_survive_an_unrelated_commit(
+        self, db_app, seeded
+    ):
+        """Why the flag can't be used as a parameter: the session is shared.
+
+        Pins the mechanism itself, so a future 'just set it on the link'
+        shortcut fails here rather than in production.
+        """
+        from shuffify.models.db import RaidPlaylistLink
+        from shuffify.services.base import safe_commit
+
+        with db_app.app_context():
+            link = RaidPlaylistLink.query.filter_by(
+                target_playlist_id="target1"
+            ).first()
+            link.drip_enabled = True
+            safe_commit("some unrelated write in the same request")
+
+        assert _stored_drip_enabled(db_app) is True
+
+
+class TestForcedDripStillRuns:
+    def test_force_param_bypasses_the_drip_enabled_gate(self, db_app, seeded):
+        """The feature must keep working with drip_enabled False."""
+        from shuffify.enums import JobType
+        from shuffify.models.db import Schedule
+        from shuffify.services.executors.drip_executor import execute_drip
+
+        schedule = Schedule(
+            user_id=seeded,
+            job_type=JobType.DRIP,
+            target_playlist_id="target1",
+            target_playlist_name="Target",
+            algorithm_params={"force": True, "drip_count": 3},
+            is_enabled=True,
+        )
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = []
+
+        with db_app.app_context():
+            result = execute_drip(schedule, api)
+
+        assert result.get("skipped_reason") != "drip_disabled"
+
+    def test_unforced_drip_still_respects_the_gate(self, db_app, seeded):
+        """A scheduled drip on a disabled link must still skip."""
+        from shuffify.enums import JobType
+        from shuffify.models.db import Schedule
+        from shuffify.services.executors.drip_executor import execute_drip
+
+        schedule = Schedule(
+            user_id=seeded,
+            job_type=JobType.DRIP,
+            target_playlist_id="target1",
+            target_playlist_name="Target",
+            algorithm_params={"drip_count": 3},
+            is_enabled=True,
+        )
+        api = MagicMock()
+        api.get_playlist_tracks.return_value = []
+
+        with db_app.app_context():
+            result = execute_drip(schedule, api)
+
+        assert result["skipped_reason"] == "drip_disabled"
+
+    def test_execute_drip_for_user_marks_the_run_as_forced(self, db_app, seeded):
+        """The intent travels in params, not on the link."""
+        from shuffify.services.executors import JobExecutorService
+
+        with db_app.app_context():
+            with patch.object(
+                JobExecutorService, "_run_job", return_value={"status": "success"}
+            ) as run_job:
+                JobExecutorService.execute_drip_for_user(
+                    user_id=seeded,
+                    target_playlist_id="target1",
+                    target_playlist_name="Target",
+                    drip_count=3,
+                )
+
+        schedule = run_job.call_args[0][0]
+        assert schedule.algorithm_params["force"] is True
+        assert schedule.algorithm_params["drip_count"] == 3


### PR DESCRIPTION
## Why

SR-021 is filed as a structural item — "`RaidSyncService` is a ~740-line orchestration god-class" — with the ORM mutation noted as a design wart: *"mutates ORM state as an implicit parameter (`link.drip_enabled = True` in memory only)."*

**"In memory only" doesn't hold.** That mutation sits pending on the request's shared SQLAlchemy session, and the drip path commits for entirely unrelated reasons. `drip_executor._mark_dripped_as_promoted` calls `safe_commit("mark dripped tracks as promoted")` on the success path, and the pending flag is flushed with it.

So: **one manual "Drip Now", on a link with drip disabled and no drip schedule, permanently enables drip on that raid link.** Nothing resets it — the only other writers are the explicit configuration routes. The flag is user-visible (`RaidPlaylistLink.to_dict()` exposes it) and it gates every future scheduled drip.

### Proven before fixing

Pending mutation plus an unrelated commit on the same session, read back from a fresh session:

```
[pending mutation + unrelated commit] drip_enabled False -> True
```

Reachability of that commit from `drip_now`'s inline path:

```
drip_now → execute_drip_for_user → _run_job → execute_drip → _mark_dripped_as_promoted → safe_commit
```

The gate it was working around is `drip_executor.py:56`, `if not link.drip_enabled:`.

## Severity — larger than the label

The label is "god-class refactor," which reads as an aesthetics item that can wait. Inside it is a data-integrity bug that silently rewrites a user's stored configuration from a one-off action. That half is not a refactor and shouldn't be sequenced behind one.

The rest of SR-021 — actually splitting the 632-line service into schedule-orchestration and execution facades — is untouched here and is still worth doing on its own.

## What changed

The forced-run intent travels in the transient `Schedule`'s `algorithm_params`, next to `drip_count`, which is already how that object carries parameters into the executor. The link is never touched, so there is no pending mutation to leak. `execute_drip` honours `force` at the gate.

Note the old docstring on `execute_drip_for_user` stated the contract out loud — *"The caller must ensure drip is enabled on the raid link"* — which is exactly the side-channel. That's gone.

## Verification

- **2048 passed, 1 skipped**, 0 failed. `flake8 shuffify/` clean.
- **Five tests**, covering both directions: the link stays untouched, a forced run still bypasses the gate, an unforced run still respects it, and the params carry the intent.
- **Mutation-checked both halves.** Restoring `link.drip_enabled = True` fails the leak test; removing the `force` check fails the forced-run test.
- One of those tests pins the *mechanism* — a pending link mutation surviving an unrelated commit — so a future "just set it on the link" shortcut fails in the suite instead of in production.

**A note on the first version of that test:** it mocked `execute_drip_for_user`, which is where the commit lives, so it passed whether or not the bug was present. The mutation check is what caught it. The stand-in now commits the session the way the real drip path does.

---

## The rest of #457, measured at this HEAD

Branden's triage said 6 of 6 live; that holds. Two corrections to the sequencing note in the issue:

**Both stated blockers are closed.** #457 says "#448 (SR-010) and #451 (SR-013) unblock SR-021 and SR-028 respectively." Both are **CLOSED**, so SR-021 and SR-028 are unblocked now — the sequencing note is stale.

| item | measured at HEAD `403c58b` | read |
|---|---|---|
| SR-021 | `raid_sync_service.py` 632 lines | **split still open**; the data-integrity half is this PR |
| SR-022 | `playlist_service.py` 444 + `public_scraper_pathway.py` 729 | large; a shared-scraper extraction, PR-sized on its own |
| SR-023 | `apply_shuffle_to_tracks` — **0 hits**, helper absent | PR-sized |
| SR-024 | `auto_snapshot_if_enabled` — **0 hits**, helper absent; snapshot references: raid 17, drip 10, rotate 8, shuffle 8 | PR-sized; carries the #447/SR-009 raid snapshot gap |
| SR-028 | `raid_panel.py` 1,278 lines, 25 routes | large mechanical, now unblocked |
| SR-029 | `models/db.py` 1,257 lines, 15 models | large mechanical |

**Not verified:** I did not test whether SR-022's two scrapers or SR-023's two shuffle paths have *behaviourally* diverged — both findings assert drift, and confirming it needs a differential test per pathway rather than a line count. That's the thing worth doing before either gets sized as "mechanical," and it may move them in either direction. Flagging it rather than implying the counts above settle it.

Six items of this size are not one reviewable PR. This one ships the piece with a proven user-visible defect; the remainder are each PR-sized and independent.
