### PR TITLE
fix(workshop): close the script block that orphaned the pending-raids loader

### DIFF
--- a/shuffify/templates/workshop.html
+++ b/shuffify/templates/workshop.html
@@ -2905,7 +2905,6 @@ function toggleCollapsiblePanel(name) {
     chevron.classList.toggle('rotate-180', isHidden);
     if (btn) btn.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
 }
-</script>
 
 
 // =============================================================================


### PR DESCRIPTION
# fix(workshop): close the script block that orphaned the pending-raids loader

Branch: `fix/458-orphaned-script-block` (pushed, commit `62cd5c6`). One line deleted.

Found while surveying `workshop.html` for #458 SR-026. Filing it on its own because it is a live functional bug with a one-line fix, and it should not wait on a 4,100-line refactor.

## The bug

`workshop.html` had **10 `<script>` opens against 11 closes**. A stray `</script>` at line 2908 closed its block early, leaving the next 16 lines — the `DOMContentLoaded` handler that fetches the pending-raids count and paints the badge — sitting in the document as **text**, not script.

```
-</script>


 // =============================================================================
 // Initialize: load pending raids badge count on page load
```

## Evidence

Measured against the real rendered page in Chromium, not inferred from the diff:

| | before | after |
|---|---|---|
| requests to `/playlist/<id>/pending-raids` on load | **0** | **1** |
| orphaned JS text nodes (HTML parser, real rendered page) | **1** | **0** |
| `<script>` open/close balance in template | 10 / **11** | 10 / 10 |

So the pending-raids badge was never populated on page load.

I checked whether the orphaned source is *visible* to users and could not answer it faithfully — my harness serves `/static` as 204, so Tailwind is absent and the layout is not representative. The DOM fact holds regardless (it is a text node in a rendered `<div>`); whether production CSS hides it is unverified, and I would rather say so than show a misleading screenshot.

## Checks

`pytest -m "not integration"` → 2042 passed. Template still parses (Jinja), and the tag balance is now even.

## Why this belongs to the SR-026 argument

#458 argues in the abstract that a 5,400-line template "cannot be linted, unit-tested, or reviewed safely". This is that argument's concrete form: an unbalanced tag survived review and ~unknown time in production because nothing lints this file and no test renders it.

Not merging my own work.
