### PR TITLE
fix(templates): migrate the remaining 30 inline handlers — completes #499

### DIFF
--- a/shuffify/templates/dashboard.html
+++ b/shuffify/templates/dashboard.html
@@ -58,7 +58,7 @@
                 <div class="flex items-center space-x-2 flex-shrink-0">
                     <!-- Manage Button -->
                     <button id="manage-btn"
-                            onclick="toggleManageMode()"
+                            data-action-click="dash-001"
                             class="inline-flex items-center px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-white font-medium transition duration-150 border border-white/20 hover:border-white/30"
                             title="Manage playlist tiles">
                         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -68,7 +68,7 @@
                     </button>
                     <!-- Refresh Playlists Button -->
                     <button id="refresh-playlists-btn"
-                            onclick="refreshPlaylists()"
+                            data-action-click="dash-002"
                             class="inline-flex items-center px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-white font-medium transition duration-150 border border-white/20 hover:border-white/30"
                             title="Refresh playlists from Spotify">
                         <svg id="refresh-icon" class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -116,7 +116,7 @@
             </div>
             <div class="flex items-center space-x-2">
                 <button id="show-hidden-btn"
-                        onclick="toggleShowHidden()"
+                        data-action-click="dash-003"
                         class="inline-flex items-center px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 text-white text-sm font-medium transition border border-white/20"
                         title="Show hidden playlists">
                     <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -125,7 +125,7 @@
                     </svg>
                     <span id="show-hidden-text">Show Hidden</span>
                 </button>
-                <button onclick="resetPreferences()"
+                <button data-action-click="dash-004"
                         class="inline-flex items-center px-3 py-1.5 rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-200 text-sm font-medium transition border border-red-500/30"
                         title="Reset all tile preferences">
                     <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -169,7 +169,7 @@
         {% if hidden_playlists %}
         <div id="hidden-playlists-section" class="mt-8">
             <button id="hidden-toggle-btn"
-                    onclick="toggleHiddenSection()"
+                    data-action-click="dash-005"
                     class="w-full flex items-center justify-between px-4 py-3 rounded-xl backdrop-blur-md bg-white/5 border border-white/10 hover:bg-white/10 transition duration-150 cursor-pointer"
                     aria-expanded="false"
                     aria-controls="hidden-grid-wrapper">
@@ -829,7 +829,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         tile.addEventListener('click', (e) => {
             // If the click is on an interactive element inside the overlay, let it through
-            if (e.target.closest('.algo-icon-btn, .algo-settings-btn, .algo-popover-close, .algo-popover-shuffle, .undo-overlay-btn, a, button, input, select')) {
+            // [data-action-click] keeps this guard correct for controls migrated off
+            // inline onclick handlers: those used to call stopPropagation themselves,
+            // which a delegated handler cannot do -- it runs at the document, after
+            // bubbling. The check belongs here, on the parent, not on each child.
+            if (e.target.closest('.algo-icon-btn, .algo-settings-btn, .algo-popover-close, .algo-popover-shuffle, .undo-overlay-btn, [data-action-click], a, button, input, select')) {
                 return;
             }
             // If click is on the Spotify link in the info bar, let it through
@@ -1042,4 +1046,34 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 }
 </style>
+<script nonce="{{ csp_nonce }}">
+// ---------------------------------------------------------------------------
+// Event wiring: inline on* attributes cannot run under the CSP (a nonce
+// authorises an element, not an attribute), so each one is registered here
+// and dispatched by static/js/actions.js. This block must stay OUTSIDE any
+// Jinja conditional -- a registry that renders conditionally orphans every key
+// on the branches where it does not render.
+// ---------------------------------------------------------------------------
+registerActions({
+    // was onclick="toggleManageMode()"
+    'dash-001': function (el, event) { toggleManageMode(); },
+    // was onclick="refreshPlaylists()"
+    'dash-002': function (el, event) { refreshPlaylists(); },
+    // was onclick="toggleShowHidden()"
+    'dash-003': function (el, event) { toggleShowHidden(); },
+    // was onclick="resetPreferences()"
+    'dash-004': function (el, event) { resetPreferences(); },
+    // was onclick="toggleHiddenSection()"
+    'dash-005': function (el, event) { toggleHiddenSection(); },
+
+// playlist_card (macros/cards.html) is rendered only by this page. Its controls
+// previously called event.stopPropagation() themselves; that guard now lives on
+// the .card-tile handler above, which skips clicks landing on [data-action-click].
+    'card.favorite': function (el) { toggleFavorite(el.dataset.playlistId); },
+    'card.hide': function (el) { hidePlaylist(el.dataset.playlistId); },
+    'card.unhide': function (el) { unhidePlaylist(el.dataset.playlistId); },
+    'card.visibility': function (el) { togglePlaylistVisibility(el.dataset.playlistId, el); },
+});
+</script>
+
 {% endblock %}

--- a/shuffify/templates/errors/500.html
+++ b/shuffify/templates/errors/500.html
@@ -28,7 +28,7 @@
                     </svg>
                     Back to Dashboard
                 </a>
-                <button onclick="window.location.reload()"
+                <button data-action-click="err-001"
                         class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-white/10 hover:bg-white/20 text-white font-medium transition duration-150 border border-white/20">
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
@@ -39,4 +39,18 @@
         </div>
     </div>
 </div>
+<script nonce="{{ csp_nonce }}">
+// ---------------------------------------------------------------------------
+// Event wiring: inline on* attributes cannot run under the CSP (a nonce
+// authorises an element, not an attribute), so each one is registered here
+// and dispatched by static/js/actions.js. This block must stay OUTSIDE any
+// Jinja conditional -- a registry that renders conditionally orphans every key
+// on the branches where it does not render.
+// ---------------------------------------------------------------------------
+registerActions({
+    // was onclick="window.location.reload()"
+    'err-001': function (el, event) { window.location.reload(); },
+});
+</script>
+
 {% endblock %}

--- a/shuffify/templates/macros/cards.html
+++ b/shuffify/templates/macros/cards.html
@@ -42,7 +42,7 @@
             <button type="button"
                     class="manage-pin-btn w-7 h-7 rounded-full bg-black/60 flex items-center justify-center transition hover:bg-black/80"
                     data-playlist-id="{{ playlist.id }}"
-                    onclick="event.stopPropagation(); toggleFavorite('{{ playlist.id }}')"
+                    data-action-click="card.favorite" data-playlist-id="{{ playlist.id }}"
                     title="{{ 'Unfavorite' if is_fav else 'Favorite' }}">
                 <svg class="w-4 h-4 {{ 'text-yellow-400' if is_fav else 'text-white/80 hover:text-yellow-400' }}" fill="{{ 'currentColor' if is_fav else 'none' }}" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
@@ -52,7 +52,7 @@
             <button type="button"
                     class="manage-hide-btn w-7 h-7 rounded-full bg-black/60 flex items-center justify-center text-white/80 hover:text-red-400 hover:bg-black/80 transition"
                     data-playlist-id="{{ playlist.id }}"
-                    onclick="event.stopPropagation(); hidePlaylist('{{ playlist.id }}')"
+                    data-action-click="card.hide" data-playlist-id="{{ playlist.id }}"
                     title="Hide playlist">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21"></path>
@@ -67,7 +67,6 @@
         {# Workshop shortcut #}
         <a href="{{ url_for('main.workshop', playlist_id=playlist.id) }}"
            class="pointer-events-auto w-6 h-6 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center transition duration-150 text-white/80 hover:text-spotify-green"
-           onclick="event.stopPropagation();"
            title="Open Workshop"
            aria-label="Open {{ playlist.name }} in Workshop">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -77,7 +76,7 @@
         {# Star/Favorite toggle #}
         <button type="button"
                 class="fav-btn pointer-events-auto w-6 h-6 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center transition duration-150"
-                onclick="event.stopPropagation(); toggleFavorite('{{ playlist.id }}')"
+                data-action-click="card.favorite" data-playlist-id="{{ playlist.id }}"
                 title="{{ 'Remove from Favorites' if is_fav else 'Add to Favorites' }}"
                 aria-label="{{ 'Remove from Favorites' if is_fav else 'Add to Favorites' }}">
             <svg class="w-3 h-3 {{ 'text-yellow-400' if is_fav else 'text-white/80 hover:text-yellow-400' }}" fill="{{ 'currentColor' if is_fav else 'none' }}" stroke="currentColor" viewBox="0 0 24 24">
@@ -87,7 +86,7 @@
         {# Public/Private visibility toggle #}
         <button type="button"
                 class="visibility-btn pointer-events-auto w-6 h-6 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center transition duration-150"
-                onclick="event.stopPropagation(); togglePlaylistVisibility('{{ playlist.id }}', this)"
+                data-action-click="card.visibility" data-playlist-id="{{ playlist.id }}"
                 data-public="{{ 'true' if playlist.public else 'false' }}"
                 title="{{ 'Make private' if playlist.public else 'Make public' }}"
                 aria-label="{{ 'Make private' if playlist.public else 'Make public' }}">
@@ -111,7 +110,7 @@
         {# Unhide button for hidden section #}
         <button type="button"
                 class="unhide-btn pointer-events-auto w-6 h-6 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center text-white/80 hover:text-green-400 transition duration-150"
-                onclick="event.stopPropagation(); unhidePlaylist('{{ playlist.id }}')"
+                data-action-click="card.unhide" data-playlist-id="{{ playlist.id }}"
                 title="Unhide playlist"
                 aria-label="Unhide playlist">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -123,7 +122,7 @@
         {# Hide button for favorites/regular sections #}
         <button type="button"
                 class="hide-btn pointer-events-auto w-6 h-6 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center text-white/80 hover:text-red-400 transition duration-150"
-                onclick="event.stopPropagation(); hidePlaylist('{{ playlist.id }}')"
+                data-action-click="card.hide" data-playlist-id="{{ playlist.id }}"
                 title="Hide playlist"
                 aria-label="Hide playlist">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -174,7 +173,6 @@
                target="_blank"
                rel="noopener noreferrer"
                class="bg-black/50 rounded-full p-2 transform transition-all duration-300 hover:scale-110 hover:bg-spotify-green"
-               onclick="event.stopPropagation();"
                aria-label="Open {{ playlist.name }} on Spotify">
                 <svg class="w-6 h-6 text-white" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
@@ -194,7 +192,6 @@
                target="_blank"
                rel="noopener noreferrer"
                class="flex-shrink-0 ml-2 bg-black/40 rounded-full p-1 text-white/80 hover:text-white hover:bg-spotify-green/80 transition duration-150"
-               onclick="event.stopPropagation();"
                title="Open on Spotify"
                aria-label="Open {{ playlist.name }} on Spotify">
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
@@ -293,8 +290,7 @@
             <div class="flex items-center space-x-2">
                 <a href="{{ url_for('main.workshop', playlist_id=playlist.id) }}"
                    class="flex-1 inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-spotify-green/80 hover:bg-spotify-green text-white text-sm font-semibold transition duration-150 border border-white/20"
-                   title="Open Playlist Workshop"
-                   onclick="event.stopPropagation();">
+                   title="Open Playlist Workshop">
                     <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                     </svg>

--- a/shuffify/templates/macros/forms.html
+++ b/shuffify/templates/macros/forms.html
@@ -1,13 +1,13 @@
 {# macros/forms.html - Reusable form field macros #}
 
-{% macro select_field(label, field_id, field_name, options, selected='', help_text='', onchange='') %}
+{% macro select_field(label, field_id, field_name, options, selected='', help_text='') %}
 <div>
   <label for="{{ field_id }}" class="block text-sm font-medium text-white/90 mb-1">
     {{ label }}
   </label>
   <select id="{{ field_id }}" name="{{ field_name }}"
           class="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-white focus:ring-2 focus:ring-white/30 focus:border-transparent"
-          {% if onchange %}onchange="{{ onchange }}"{% endif %}>
+          >
     {% for option in options %}
     <option value="{{ option.value }}"
             {% if option.value == selected %}selected{% endif %}

--- a/shuffify/templates/schedules.html
+++ b/shuffify/templates/schedules.html
@@ -21,7 +21,7 @@
                     </div>
                 </div>
                 <button id="new-schedule-btn"
-                        onclick="showCreateModal()"
+                        data-action-click="sched-001"
                         class="inline-flex items-center px-4 py-2 rounded-lg bg-white text-spotify-dark font-bold transition duration-150 hover:bg-green-100 shadow-lg">
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -100,21 +100,21 @@
 
                     <!-- Actions -->
                     <div class="flex items-center space-x-2 flex-shrink-0">
-                        <button onclick="toggleEditPanel({{ schedule.id }})"
+                        <button data-action-click="sched.edit" data-schedule-id="{{ schedule.id }}"
                                 class="p-2 rounded-lg bg-white/10 hover:bg-white/20 text-white transition duration-150 border border-white/20"
                                 title="Edit">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                             </svg>
                         </button>
-                        <button onclick="toggleHistory({{ schedule.id }})"
+                        <button data-action-click="sched.history" data-schedule-id="{{ schedule.id }}"
                                 class="p-2 rounded-lg bg-white/10 hover:bg-white/20 text-white transition duration-150 border border-white/20"
                                 title="Execution History">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
                         </button>
-                        <button onclick="runScheduleNow({{ schedule.id }})"
+                        <button data-action-click="sched.run" data-schedule-id="{{ schedule.id }}"
                                 class="p-2 rounded-lg bg-white/10 hover:bg-white/20 text-white transition duration-150 border border-white/20"
                                 title="Run Now">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -122,7 +122,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
                         </button>
-                        <button onclick="toggleSchedule({{ schedule.id }})"
+                        <button data-action-click="sched.toggle" data-schedule-id="{{ schedule.id }}"
                                 class="p-2 rounded-lg bg-white/10 hover:bg-white/20 text-white transition duration-150 border border-white/20"
                                 title="{{ 'Pause' if schedule.is_enabled else 'Enable' }}">
                             {% if schedule.is_enabled %}
@@ -135,7 +135,7 @@
                             </svg>
                             {% endif %}
                         </button>
-                        <button onclick="deleteSchedule({{ schedule.id }})"
+                        <button data-action-click="sched.delete" data-schedule-id="{{ schedule.id }}"
                                 class="p-2 rounded-lg bg-red-500/20 hover:bg-red-500/40 text-red-300 transition duration-150 border border-red-500/30"
                                 title="Delete">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -169,7 +169,7 @@
 
 <!-- Create Schedule Modal -->
 <div id="create-modal" class="fixed inset-0 z-50 hidden">
-    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="hideCreateModal()"></div>
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-action-click="sched-002"></div>
     <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full max-w-lg max-h-[90vh] overflow-y-auto">
         <div class="rounded-2xl shadow-2xl bg-spotify-dark border border-white/20 p-6">
             <h2 class="text-xl font-bold text-white mb-4">New Scheduled Operation</h2>
@@ -180,7 +180,7 @@
                     <label class="block text-sm font-medium text-white/90 mb-1">Operation Type</label>
                     <select id="modal-job-type" name="job_type"
                             class="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-white"
-                            onchange="updateModalFields()">
+                            data-action-change="sched-003">
                         <option value="raid">Raid (pull new tracks from sources)</option>
                         <option value="shuffle">Shuffle (reorder playlist)</option>
                         <option value="raid_and_shuffle">Raid + Shuffle (pull then shuffle)</option>
@@ -194,7 +194,7 @@
                 <div>
                     <label class="block text-sm font-medium text-white/90 mb-1">Target Playlist</label>
                     <select id="modal-target-playlist" name="target_playlist"
-                            onchange="onTargetPlaylistChange()"
+                            data-action-change="sched-004"
                             class="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-white">
                         {% for pl in playlists %}
                         <option value="{{ pl.id }}" data-name="{{ pl.name }}">{{ pl.name }}</option>
@@ -263,7 +263,7 @@
                 <div>
                     <label class="block text-sm font-medium text-white/90 mb-1">Frequency</label>
                     <select id="modal-frequency" name="schedule_value"
-                            onchange="updateTimePickerVisibility()"
+                            data-action-change="sched-005"
                             class="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-white">
                         <option value="every_6h">Every 6 hours</option>
                         <option value="every_12h">Every 12 hours</option>
@@ -284,7 +284,7 @@
 
                 <!-- Buttons -->
                 <div class="flex space-x-3 pt-2">
-                    <button type="button" onclick="hideCreateModal()"
+                    <button type="button" data-action-click="sched-006"
                             class="flex-1 px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-white font-medium transition border border-white/20">
                         Cancel
                     </button>
@@ -475,7 +475,7 @@ function renderRaidSources(targetId) {
         <label class="flex items-center space-x-2 px-2 py-1 rounded hover:bg-white/5 cursor-pointer">
             <input type="checkbox" name="source_playlist" value="${escapeAttr(src.source_playlist_id)}"
                    class="rounded border-white/30 bg-white/10 text-spotify-green focus:ring-spotify-green"
-                   onchange="updateCreateButtonState()">
+                   data-action-change="sched.create-btn-state">
             <span class="text-white/80 text-sm truncate">${escapeHtml(src.source_name || src.source_playlist_id)}</span>
             <span class="ml-auto px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-300 border border-blue-500/30">external</span>
         </label>
@@ -755,4 +755,34 @@ function deleteSchedule(scheduleId) {
 }
 
 </script>
+<script nonce="{{ csp_nonce }}">
+// ---------------------------------------------------------------------------
+// Event wiring: inline on* attributes cannot run under the CSP (a nonce
+// authorises an element, not an attribute), so each one is registered here
+// and dispatched by static/js/actions.js. This block must stay OUTSIDE any
+// Jinja conditional -- a registry that renders conditionally orphans every key
+// on the branches where it does not render.
+// ---------------------------------------------------------------------------
+registerActions({
+    // was onclick="showCreateModal()"
+    'sched-001': function (el, event) { showCreateModal(); },
+    // was onclick="hideCreateModal()"
+    'sched-002': function (el, event) { hideCreateModal(); },
+    // was onchange="updateModalFields()"
+    'sched-003': function (el, event) { updateModalFields(); },
+    // was onchange="onTargetPlaylistChange()"
+    'sched-004': function (el, event) { onTargetPlaylistChange(); },
+    // was onchange="updateTimePickerVisibility()"
+    'sched-005': function (el, event) { updateTimePickerVisibility(); },
+    // was onclick="hideCreateModal()"
+    'sched-006': function (el, event) { hideCreateModal(); },
+    'sched.edit': function (el) { toggleEditPanel(Number(el.dataset.scheduleId)); },
+    'sched.history': function (el) { toggleHistory(Number(el.dataset.scheduleId)); },
+    'sched.run': function (el) { runScheduleNow(Number(el.dataset.scheduleId)); },
+    'sched.toggle': function (el) { toggleSchedule(Number(el.dataset.scheduleId)); },
+    'sched.delete': function (el) { deleteSchedule(Number(el.dataset.scheduleId)); },
+    'sched.create-btn-state': function () { updateCreateButtonState(); },
+});
+</script>
+
 {% endblock %}


### PR DESCRIPTION
Completes #499. #523 proved the shape on one page; this migrates the remaining 30 handlers across the other five files.

**Zero inline `on*` handlers now remain anywhere in `shuffify/templates`** — both quote styles, markup and runtime-generated strings alike.

| file | handlers |
|---|---|
| `schedules.html` | 12 (11 markup + 1 runtime-generated) |
| `macros/cards.html` | 10 |
| `dashboard.html` | 5 |
| `macros/forms.html` | 2 |
| `errors/500.html` | 1 |

## Verified under real CSP, in Chromium

Both pages rendered through the app's own route + template stack, served with the app's real `Content-Security-Policy` header and the repo's real `static/`:

| | bound | dispatched | orphan keys | duplicate keys | CSP violations |
|---|---|---|---|---|---|
| `dashboard` | 24 | **24** | 0 | 0 | **0** |
| `schedules` | 11 | **11** | 0 | 0 | **0** |

Duplicate-key count comes from the collision guard navi asked for in #523 — it is now doing real work across a much wider key space (`card.*`, `sched.*`, `dash-*`, `err-*`).

## The pair, and the two-sided guard check

`macros/cards.html` and `dashboard.html` are in **one commit deliberately**: the guard lives in one file and the handlers in the other, and a half-landed pair means either double-firing links or dead controls — both silent.

All 10 `cards.html` handlers called `event.stopPropagation()` themselves and 4 did nothing else. A delegated handler cannot reproduce that: it runs at the document, after bubbling is finished. It does not need to — the `.card-tile` handler already skips clicks landing on interactive children, so the guard moves from child to parent, where it already lived. `[data-action-click]` is added to that selector list and all 10 calls are deleted.

The check that matters is **two-sided**, because a one-sided version passes while breaking the overlay:

```json
{ "actionFired": true,
  "overlayChangedByControlClick": false,     // guard blocks: control does NOT toggle the tile
  "overlayChangedByArtworkClick": true }     // guard does not over-block: artwork still toggles
```

Testing only the first line would have looked green with a guard so broad it disabled the overlay entirely.

**Worth recording, because the next person will not reconstruct it:** those 10 `stopPropagation` calls have been CSP-blocked for ~10 weeks, so the `.card-tile` guard is the *only* reason nested card links have not been double-firing that whole time. One defect was masking another. Un-blocking the handlers without adding `[data-action-click]` to that selector would have surfaced the second defect instantly — and it would have looked like this PR caused it.

## `macros/forms.html` — deleted, not migrated

`select_field`'s `onchange` parameter is dead: no caller anywhere passes it, so the `{% if onchange %}` branch never rendered. Removed the parameter rather than converting a handler that never existed.

## A trap for anyone with a pre-#513 branch

#513 changed CI's lint step from `flake8` to `ruff`. A branch cut before that still contains the **old** `ci.yml`, so "run the workflow locally" runs `flake8` and passes while CI runs `ruff`. Local-CI parity silently tests the wrong linter. I hit this on the #523 merge; the fix is to read the workflow from `origin/main`, not from your branch.

Related: I also ran mason's #527 duplicate-revision check even though this branch adds no migrations — no duplicate revision ids, single head `e6f7a8b9c0d1`.

## Checks

All three CI jobs run locally against the rebased tree, with **ruff** rather than flake8: `build-css.sh --check` OK · `ruff check shuffify/` clean · `pytest -m "not integration"` **2085 passed**.

Rebased onto `5dc653f`; one commit, five files, no Python touched.

Not merging my own work.
