### PR TITLE
Set up Cursor Cloud dev environment + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+General developer/architecture guidance for this repo lives in `CLAUDE.md`
+(setup, commands, layering, models, algorithms). Read it first. This file only
+adds Cursor Cloud specific notes.
+
+## Cursor Cloud specific instructions
+
+Shuffify is a single Flask web app (one process; APScheduler runs in-process).
+Standard lint/test/build/run commands are documented in `CLAUDE.md` — use those.
+Notes below are the non-obvious, environment-specific bits.
+
+### Python env
+- Dependencies live in a virtualenv at `/workspace/venv`. Activate it before any
+  command: `source venv/bin/activate`. The startup update script refreshes it
+  from `requirements/dev.txt`.
+
+### Running the app
+- Dev server: `source venv/bin/activate && python run.py` → serves on
+  `http://localhost:8000` (binds `0.0.0.0`). Health check: `GET /health`.
+- `APP_CONFIG` defaults to `development` (SQLite at `shuffify_dev.db`). `run.py`
+  reads env, not `.env`, first; a `.env` file (git-ignored) is created during
+  setup with dev config + placeholder Spotify credentials.
+
+### No Redis / Postgres here — this is expected, not a failure
+- Neither service runs in this environment. The app auto-falls back: filesystem
+  sessions (`./.flask_session/`), no Spotify API caching, in-memory rate limiting,
+  and SQLite instead of Postgres. The startup log lines "Redis connection
+  failed... Falling back to filesystem sessions" and "Rate limiter using
+  in-memory storage" are normal here.
+
+### Spotify OAuth is the one thing you cannot fully exercise
+- Login → pick playlist → shuffle in the browser requires real
+  `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` from a Spotify Developer app plus
+  a real Spotify account. These are not available by default, so `/login` just
+  bounces back to `/` with placeholder creds. To test end to end, add those as
+  secrets and set the dashboard redirect URI to `http://localhost:8000/callback`.
+- The core product logic (the 7 shuffle algorithms in
+  `shuffify/shuffle_algorithms/`) is fully testable without Spotify — import
+  `ShuffleRegistry` and call `.shuffle(tracks)` on sample track dicts.
+
+### Tests
+- `pytest tests/ -m "not integration"` runs without any env vars: `config.py`
+  skips `load_dotenv()` under pytest and fixtures force `TestConfig`
+  (in-memory SQLite, scheduler off). `@pytest.mark.integration` tests hit live
+  public Spotify pages and need network; skip them unless intended.
+- `./scripts/build-css.sh --check` (a CI gate) downloads a standalone Tailwind
+  CLI binary from GitHub on first run, so it needs outbound network.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Shuffify in Cursor Cloud and captures durable, non-obvious startup/run guidance for future agents.

The only code/repo change is a new `AGENTS.md`; everything else (venv, `.env`, dependency install) is environment setup captured by the startup update script and VM snapshot — no application code was modified.

## Environment setup

- Python `3.12.3`; installed system `python3.12-venv`, created `/workspace/venv`, and installed `requirements/dev.txt`.
- Created a git-ignored `.env` with `development` config, SQLite, and placeholder Spotify credentials.
- No Redis/Postgres in this environment — the app gracefully falls back to filesystem sessions, in-memory rate limiting, and SQLite (expected warnings, not errors).

## Verification (all green)

| Check | Command | Result |
|-------|---------|--------|
| Lint | `ruff check shuffify/` | All checks passed |
| Tests | `pytest tests/ -m "not integration"` | 2139 passed, 22 deselected |
| CSS gate | `./scripts/build-css.sh --check` | OK — committed stylesheet matches |
| Run | `python run.py` → `GET /health` | `{"status": "healthy"}` |
| Core logic | `ShuffleRegistry` BasicShuffle on a sample playlist | 10 tracks preserved, order changed |

## Hello-world

Exercised the product's core functionality — the shuffle engine — through the real application code (reordered a sample playlist via `ShuffleRegistry`), and loaded the full UI + `/health` in a browser.

Full Spotify OAuth login → shuffle-in-browser could not be exercised because it requires real `SPOTIFY_CLIENT_ID`/`SPOTIFY_CLIENT_SECRET` from a Spotify Developer app plus a real account, which aren't available in this environment.

[shuffify_ui_walkthrough.mp4](https://cursor.com/agents/bc-14802e6c-d5ae-4646-b994-7aff9fd198b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshuffify_ui_walkthrough.mp4)

[Shuffify landing page](https://cursor.com/agents/bc-14802e6c-d5ae-4646-b994-7aff9fd198b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshuffify_landing.webp)
[Shuffify health endpoint](https://cursor.com/agents/bc-14802e6c-d5ae-4646-b994-7aff9fd198b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshuffify_health.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14802e6c-d5ae-4646-b994-7aff9fd198b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14802e6c-d5ae-4646-b994-7aff9fd198b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

