### PR TITLE
docs(agents): note /login legal_consent requirement for OAuth testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,11 @@ Notes below are the non-obvious, environment-specific bits.
 - The core product logic (the 7 shuffle algorithms in
   `shuffify/shuffle_algorithms/`) is fully testable without Spotify — import
   `ShuffleRegistry` and call `.shuffle(tracks)` on sample track dicts.
+- Gotcha when testing OAuth: `GET /login` requires a `legal_consent` query param
+  (set by the landing page's Terms checkbox). A bare `GET /login` flashes an
+  error and redirects to `/`; use `/login?legal_consent=true` to reach the real
+  Spotify authorize redirect. Completing the login itself needs a human Spotify
+  account (reCAPTCHA/MFA on `accounts.spotify.com`) and cannot be automated.
 
 ### Tests
 - `pytest tests/ -m "not integration"` runs without any env vars: `config.py`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small follow-up to the merged AGENTS.md (#540). While validating the real Spotify OAuth flow end to end, I hit a non-obvious gotcha worth recording for future agents:

- `GET /login` requires a `legal_consent` query param (set by the landing page's Terms checkbox). A bare `GET /login` flashes an error and redirects to `/`; use `/login?legal_consent=true` to reach the real Spotify authorize redirect.
- Completing the login itself needs a human Spotify account (reCAPTCHA/MFA on `accounts.spotify.com`) and cannot be automated.

No application code changes — docs only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14802e6c-d5ae-4646-b994-7aff9fd198b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14802e6c-d5ae-4646-b994-7aff9fd198b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

