### PR TITLE
docs(migrations): correct the claim that migrations run automatically in production (#531)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,7 +596,7 @@ Two config attributes decide it — `TESTING` and `MIGRATE_ON_STARTUP`:
 |-------------|-----------|----------------------|----------|
 | Tests | `True` | — | Tables built directly from the models via `db.create_all()`; no migration chain |
 | Development | `True` | `True` | Also `db.create_all()` today — `TESTING=True` short-circuits before the migration branch is reached (#325) |
-| Production | `False` | `False` | `scripts/docker-entrypoint.sh` runs `flask db upgrade` **before** Gunicorn starts; the app factory then only *verifies* the schema is at head and refuses to start if it is not |
+| Production | `False` | `False` | **Nothing applies migrations automatically** — `scripts/docker-entrypoint.sh` is bypassed on DigitalOcean App Platform (see the warning below). The app factory only *verifies* the schema is at head and refuses to start if it is not |
 
 Development does **not** currently exercise the Alembic chain: `DevConfig`
 sets `TESTING = True`, which routes it to `db.create_all()`. That is the bug
@@ -605,22 +605,51 @@ tracked in #325 — schema drift between what Alembic produces and what
 is what a non-production environment uses to opt into in-process migration
 once `TESTING` is corrected.
 
-Migrations do not run inside the production web process. Applying them once in
-the entrypoint — before Gunicorn forks — is what keeps concurrent workers from
-racing on the same upgrade, and it means a stale schema is caught at boot
-rather than surfacing as data corruption under traffic.
+> **⚠️ Production migrations are NOT automated today — do not assume a deploy applies them.**
+>
+> DigitalOcean App Platform's `run_command` **replaces** the container `ENTRYPOINT`, so
+> `scripts/docker-entrypoint.sh` has never executed in production. Confirmed from a deploy
+> log whose first line is `Starting gunicorn`, with no entrypoint output at all. Production
+> served a stale schema silently for weeks until #503's schema gate refused to boot on it.
+>
+> What follows from that, all of it current:
+>
+> - **No process runs `flask db upgrade` in production.** Migrations have to be applied
+>   deliberately; deploying does not do it.
+> - Production runs with `SHUFFIFY_ALLOW_SCHEMA_DRIFT` set, serving behind Alembic head.
+> - A **migration freeze** is in effect — no new Alembic revision merges to `main` until
+>   production's schema is reconciled. `deploy_on_push: true` makes every merge a live deploy,
+>   so an extra revision widens the gap it has to catch up across.
+>
+> The intended fix is a DigitalOcean `PRE_DEPLOY` job (`db-migrate`) running `flask db upgrade`
+> before traffic cuts over. It is **proposed, not implemented** — tracked in
+> [#531](https://github.com/chrisrogers37/shuffify/issues/531). Do not describe it here as the
+> mechanism until it exists; documenting a mechanism that does not run is what caused this.
+
+The entrypoint's rationale still holds **wherever it actually runs** — `docker run`,
+docker-compose, and any platform that honours `ENTRYPOINT`. Applying migrations once there,
+before Gunicorn forks, is what keeps concurrent workers from racing on the same upgrade, and
+it means a stale schema is caught at boot rather than surfacing as data corruption under
+traffic. It is correct code in an inert position, which is why it should be fixed in place
+rather than deleted.
 
 **`SHUFFIFY_ALLOW_SCHEMA_DRIFT`** is the break-glass override. Set it to `true`
 and the entrypoint tolerates a failed upgrade while the app factory downgrades
 the schema check to an ERROR log, so a misfiring guard can be cleared from the
 platform console in one restart instead of blocking every deploy until a fix
 ships. It is a recovery lever, not a setting — a deploy running with it set is
-serving against a schema the code does not expect.
+serving against a schema the code does not expect. **In production only the
+app-factory half of that is live**, since the entrypoint does not run there; it
+is what is currently holding production up, and it is load-bearing until #531
+is resolved.
 
-**`SHUFFIFY_MIGRATION_STEP`** is set by the entrypoint only, and exempts that
-one process from the schema check. `flask db upgrade` builds the whole app, so
-without it the check would refuse to construct the app for the very schema
-state the command exists to fix. Never set it on a process that serves traffic.
+**`SHUFFIFY_MIGRATION_STEP`** exempts one process from the schema check.
+`flask db upgrade` builds the whole app, so without it the check would refuse to
+construct the app for the very schema state the command exists to fix. In this
+repo the entrypoint is its only setter — which means **nothing sets it in
+production**, and any process there that runs `flask db upgrade` (a manual
+`console` session today, the `db-migrate` job if #531 lands) must set it
+itself. Never set it on a process that serves traffic.
 
 **Local development**: If `DATABASE_URL` is not set, the app falls back to SQLite (`sqlite:///shuffify.db`). No migration setup needed for SQLite — `db.create_all()` handles it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,19 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 # session fallback stays writable; gunicorn binds :8000 (>1024, no root needed).
 USER nobody
 
-# Apply migrations before the server starts. ENTRYPOINT rather than a longer
-# CMD so the migration step survives a platform-level run-command override --
-# those replace CMD, leaving ENTRYPOINT to wrap whatever they substitute.
+# Apply migrations before the server starts, on any platform that honours
+# ENTRYPOINT.
+#
+# CORRECTION -- the original rationale here was wrong, and the error was the
+# proximate cause of a production incident. It claimed ENTRYPOINT was chosen
+# so the migration step "survives a platform-level run-command override,
+# because those replace CMD". DigitalOcean App Platform's `run_command`
+# replaces the ENTRYPOINT too, so on production this line is inert and the
+# migration step has never run. See scripts/docker-entrypoint.sh and
+# https://github.com/chrisrogers37/shuffify/issues/531.
+#
+# Keep it: it is correct for `docker run`, docker-compose, and any platform
+# that does honour ENTRYPOINT. Just do not read it as the production path.
 ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]
 
 # Run the application

--- a/config.py
+++ b/config.py
@@ -108,9 +108,13 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # Schema management: whether the app applies Alembic migrations itself
-    # during startup. False means something outside the app has already run
-    # them -- the container entrypoint -- and the app factory only verifies
-    # the schema is at head, refusing to serve if it is not.
+    # during startup. False means something outside the app is expected to
+    # have run them already, and the app factory only verifies the schema is
+    # at head, refusing to serve if it is not.
+    #
+    # In production that "something" is currently NOTHING -- the container
+    # entrypoint meant to fill the role is bypassed by DigitalOcean App
+    # Platform, which replaces ENTRYPOINT with run_command. See issue #531.
     MIGRATE_ON_STARTUP = True
 
     # Scheduler configuration
@@ -146,7 +150,9 @@ class ProdConfig(Config):
     DEBUG = False
     TESTING = False
 
-    # Migrations run in the container entrypoint, before Gunicorn starts.
+    # Nothing applies migrations in production today: the container
+    # entrypoint that was meant to is bypassed on DigitalOcean App
+    # Platform. They must be applied deliberately. See issue #531.
     MIGRATE_ON_STARTUP = False
     SCHEDULER_ENABLED = os.getenv("SCHEDULER_ENABLED", "true").lower() == "true"
     SESSION_COOKIE_SECURE = True

--- a/documentation/production-database-setup.md
+++ b/documentation/production-database-setup.md
@@ -11,7 +11,11 @@ Shuffify uses SQLite by default for local development. For production, it suppor
 - Converts `postgres://` to `postgresql://` (for Neon/Railway compatibility)
 - Enables SSL when connecting to managed PostgreSQL providers
 - Configures connection pooling (pool size 5, recycle every 300s)
-- Runs Alembic migrations on startup to create/update all tables
+- Verifies the schema is at Alembic head on startup, and refuses to serve if it is not
+
+> **⚠️ It does NOT apply migrations for you on DigitalOcean App Platform.** See
+> [Migrations](#migrations) below before you deploy — this is currently a manual step,
+> and getting it wrong means the app will not boot.
 
 **Tables created** (14 total):
 
@@ -74,7 +78,8 @@ On the next deploy/restart, the app will:
 2. Run all Alembic migrations to create the 14 tables
 3. Begin storing user data persistently
 
-No manual migration step is needed -- migrations run automatically on startup.
+**A manual migration step IS needed on DigitalOcean App Platform** — step 2 above does
+not happen by itself there. See [Migrations](#migrations).
 
 ---
 
@@ -104,7 +109,8 @@ postgresql://postgres:password@hostname.railway.app:5432/railway
 
 ### 3. Deploy
 
-Same as Neon -- the app handles migrations automatically on startup.
+Same as Neon. Note the same caveat: on DigitalOcean App Platform the app does **not**
+apply migrations itself — see [Migrations](#migrations).
 
 ---
 
@@ -244,17 +250,39 @@ Expected output:
 
 ## Migrations
 
-### Automatic (Default)
+### On DigitalOcean App Platform: migrations are MANUAL today
 
-Migrations run automatically when the app starts. The startup logic:
+**Nothing applies migrations automatically on our production platform.** App Platform's
+`run_command` **replaces** the container `ENTRYPOINT`, so `scripts/docker-entrypoint.sh`
+— the script written to run `flask db upgrade` before Gunicorn starts — has never
+executed in production. Confirmed from a deploy log whose first line is
+`Starting gunicorn`, with no entrypoint output at all.
 
-1. Checks if a `migrations/` directory exists
-2. If yes, runs `flask db upgrade` (Alembic) to apply any pending migrations
-3. If no, falls back to `db.create_all()` (creates tables without migration history)
+The app factory still *verifies* the schema is at head and refuses to boot if it is not,
+so a missed migration surfaces as a failed deploy rather than silent corruption.
 
-### Manual (If Needed)
+**What you must do after deploying a release that adds a migration:** apply it yourself,
+using the Manual steps below, with `SHUFFIFY_MIGRATION_STEP=1` and
+`SCHEDULER_ENABLED=false` set on that process (see the note under Manual).
 
-If you need to run migrations manually (e.g., debugging):
+The intended fix is a `PRE_DEPLOY` job (`db-migrate`) that runs `flask db upgrade` before
+traffic cuts over. It is **proposed, not implemented** —
+[#531](https://github.com/chrisrogers37/shuffify/issues/531). A **migration freeze** is in
+effect until production's schema is reconciled.
+
+### Where migrations DO run automatically
+
+On any platform that honours `ENTRYPOINT` — `docker run`, docker-compose — the entrypoint
+applies them before Gunicorn starts:
+
+1. Runs `flask db upgrade` (Alembic) to apply any pending migrations
+2. Refuses to start the container if that fails, unless
+   `SHUFFIFY_ALLOW_SCHEMA_DRIFT=true`
+
+Locally with SQLite and no `DATABASE_URL`, `db.create_all()` builds the tables directly and
+there is no migration chain to apply.
+
+### Manual (required on DigitalOcean, also for debugging)
 
 ```bash
 # Set required env vars
@@ -265,8 +293,13 @@ export DATABASE_URL=postgresql://...
 # Check current migration status
 flask db current
 
-# Apply pending migrations
-flask db upgrade
+# Apply pending migrations.
+# SHUFFIFY_MIGRATION_STEP=1 exempts this process from the schema guard --
+# without it the app factory refuses to build the app for the very schema
+# state this command exists to fix.
+# SCHEDULER_ENABLED=false stops this short-lived process starting APScheduler
+# and executing scheduled jobs.
+SHUFFIFY_MIGRATION_STEP=1 SCHEDULER_ENABLED=false flask db upgrade
 
 # View migration history
 flask db history

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,8 +2,37 @@
 # Container entrypoint: reconcile the database schema, then hand off to the
 # real command.
 #
+# ============================================================================
+# THIS SCRIPT DOES NOT RUN IN PRODUCTION. Do not reason about production
+# migrations from anything below this banner.
+#
+# Production is DigitalOcean App Platform, whose `run_command` REPLACES the
+# container ENTRYPOINT rather than being passed to it. So the `exec "$@"` at
+# the bottom is never reached, because this file is never entered. Confirmed
+# from a deploy log whose first line is `Starting gunicorn`, with none of the
+# `entrypoint:` output below it.
+#
+# The consequence is not academic: production served a stale schema silently
+# for weeks, because this file existed and everyone -- humans and bots --
+# read it as the mechanism. That is the whole reason for this banner.
+#
+# Where it DOES run and is correct: `docker run`, docker-compose, and any
+# platform that honours ENTRYPOINT. Do not delete it. It is correct code in
+# an inert position.
+#
+# The intended production fix is a `PRE_DEPLOY` job (`db-migrate`) running
+# `flask db upgrade` before traffic cuts over. It is PROPOSED, NOT
+# IMPLEMENTED -- tracked in
+# https://github.com/chrisrogers37/shuffify/issues/531. Until it lands,
+# nothing applies migrations in production and a migration freeze is in
+# effect. The env-var contract below (SCHEDULER_ENABLED=false,
+# SHUFFIFY_MIGRATION_STEP=1) is the spec that job must reproduce.
+# ============================================================================
+#
 # Migrations run here -- one process, before Gunicorn forks its workers --
-# rather than inside the Flask app factory. That is what keeps concurrent
+# rather than inside the Flask app factory, ON THE PLATFORMS WHERE THIS FILE
+# ACTUALLY RUNS (see the banner above; production is not one of them). That
+# is what keeps concurrent
 # workers from racing on the same upgrade, and it lets the app factory treat
 # "schema is at head" as an invariant to verify rather than work to perform
 # while requests are already arriving.

--- a/shuffify/__init__.py
+++ b/shuffify/__init__.py
@@ -223,10 +223,16 @@ def _init_token_encryption(app):
 # schema-drift check from a startup failure to an ERROR log. It exists so a
 # misfiring guard can be cleared from the platform console in one restart,
 # rather than blocking every deploy until a code change ships.
+#
+# On production only the app-factory half is live -- the entrypoint does not
+# run there (issue #531) -- and this override is currently what keeps the
+# service up while the schema sits behind head.
 SCHEMA_DRIFT_OVERRIDE_VAR = "SHUFFIFY_ALLOW_SCHEMA_DRIFT"
 
-# Internal handshake, set by the entrypoint while it applies migrations --
-# not an operator knob. `flask db upgrade` imports run.py and builds the whole
+# Internal handshake, set by whatever process applies migrations -- in this
+# repo only the entrypoint sets it, which means nothing sets it in production
+# (issue #531). Not an operator knob. `flask db upgrade` imports run.py and
+# builds the whole
 # application, so without this the schema check would fire inside the
 # migration step and refuse to let it run: the check would be asserting the
 # very invariant that step exists to establish.
@@ -272,9 +278,12 @@ def _schema_revision_state(migrations_dir):
 def _verify_schema_at_head(migrations_dir):
     """Fail fast when the production schema is not at the migration head.
 
-    Production applies migrations in the container entrypoint, before Gunicorn
-    starts, so by the time the app factory runs "schema is at head" is an
-    invariant to check rather than work to do. The check is satisfied entirely
+    Production was designed to apply migrations in the container entrypoint
+    before Gunicorn starts, so by the time the app factory runs "schema is at
+    head" is an invariant to check rather than work to do. That entrypoint is
+    bypassed on DigitalOcean App Platform and has never run there (issue
+    #531), which is why this check fires in production rather than passing.
+    The check is satisfied entirely
     from the image -- the migration chain ships with the code -- so it cannot
     block a boot on infrastructure that has not been provisioned.
 
@@ -298,10 +307,11 @@ def _verify_schema_at_head(migrations_dir):
 
     message = (
         "Database schema is not at Alembic head: current=%s, head=%s. "
-        "Migrations are applied by the container entrypoint before Gunicorn "
-        "starts, so this means the entrypoint was bypassed or its upgrade "
-        "failed. Apply them with 'flask db upgrade', or set %s=true to start "
-        "anyway and serve against the current schema."
+        "Nothing applies migrations automatically in this deployment: the "
+        "container entrypoint is bypassed on DigitalOcean App Platform "
+        "(shuffify#531), so they must be applied deliberately. Apply them "
+        "with 'flask db upgrade', or set %s=true to start anyway and serve "
+        "against the current schema."
         % (
             current or "none (database never migrated)",
             ",".join(sorted(heads)) or "none",
@@ -321,9 +331,10 @@ def _verify_schema_at_head(migrations_dir):
 def _upgrade_schema():
     """Apply pending Alembic migrations in-process.
 
-    The development path. Production migrates in the container entrypoint;
-    running the upgrade from the app factory there would put schema mutation
-    inside every process that serves requests.
+    The development path. Production must not migrate here -- running the
+    upgrade from the app factory would put schema mutation inside every
+    process that serves requests. Production's out-of-app migration step is
+    currently missing rather than merely elsewhere (issue #531).
     """
     from flask_migrate import upgrade
 
@@ -339,8 +350,10 @@ def _init_database(app):
     - ``TESTING`` builds tables straight from the models; there is no
       migration chain to apply against in-memory SQLite.
     - ``MIGRATE_ON_STARTUP=False`` (production) means something outside the
-      app already ran ``flask db upgrade`` -- the container entrypoint -- so
-      the factory only verifies the result and refuses to serve a stale one.
+      app is expected to have run ``flask db upgrade`` already, so the factory
+      only verifies the result and refuses to serve a stale one. Today nothing
+      does: the container entrypoint intended for it is bypassed on
+      DigitalOcean App Platform (issue #531).
     - ``MIGRATE_ON_STARTUP=True`` applies migrations in-process.
 
     Note that ``DevConfig`` currently sets ``TESTING=True``, so development


### PR DESCRIPTION
Closes the documentation half of #531. **Docs and comments only — no behavior change, and the `PRE_DEPLOY` job is deliberately not implemented.**

## The defect

`CLAUDE.md`, the production setup guide, the `Dockerfile`, `config.py` and the app factory all stated that production applies Alembic migrations on startup via `scripts/docker-entrypoint.sh`.

It does not, and never has. DigitalOcean App Platform's `run_command` **replaces** the container `ENTRYPOINT`, so the entrypoint has never executed in production — confirmed by a deploy log whose first line is `Starting gunicorn`, with no entrypoint output at all.

That is why production served a stale schema silently for weeks. **A wrong doc is worse than a missing one, because it stops people looking.**

## I swept the claim, not the files it was reported in

Three files were reported. I grepped for the *claim* and found it in **six files across 23 sites**.

Searched (case-insensitive, whole tracked tree): `migrations run/runs/are run/applied/happen`, `runs alembic`, `alembic upgrade`, `flask db upgrade`, `docker-entrypoint`, `ENTRYPOINT`, `entrypoint`, `on startup`, `automatic(ally) migrat`, `migrate on startup`, `MIGRATE_ON_STARTUP`, `handles migrations automatically`, `no manual migration step`.

| File | Sites | What it claimed |
|---|---:|---|
| `documentation/production-database-setup.md` | 9 | "Runs Alembic migrations on startup", "No manual migration step is needed", "the app handles migrations automatically" |
| `shuffify/__init__.py` | 6 | docstrings + **the runtime error message** operators see during this exact failure |
| `CLAUDE.md` | 3 | the migrations table's Production row and the two env-var paragraphs under it |
| `config.py` | 2 | `MIGRATE_ON_STARTUP` comments on both base and prod config |
| `scripts/docker-entrypoint.sh` | 2 | header banner + "Migrations run here" |
| `Dockerfile` | 1 | see below |

**The Dockerfile comment was the worst of them**, and it was not in the reported list. It did not merely omit the failure mode — it explicitly ruled it out:

> ENTRYPOINT rather than a longer CMD so the migration step survives a platform-level run-command override — those replace CMD, leaving ENTRYPOINT to wrap whatever they substitute.

`run_command` replaces `ENTRYPOINT` too. That comment actively reassured every reader that the thing which happened could not happen.

## Two places I deviated from #531, deliberately

**1. #531's suggested wording would have re-introduced the same defect.** It asks the entrypoint comment to say "production migrations run via the `db-migrate` PRE_DEPLOY job". That job does not exist yet, so writing it would swap one false mechanism claim for another — the exact failure this PR exists to correct. Everything here says the job is **proposed, not implemented**, and links #531.

**2. The setup guide states the real state rather than just losing the wrong one.** It is a setup guide, so a reader follows it to stand up a new deployment; deleting "migrations run automatically" would leave them told nothing. The Migrations section now says migrations are **manual on DigitalOcean today**, gives the exact command with the two env vars that are easy to get wrong (`SHUFFIFY_MIGRATION_STEP=1`, `SCHEDULER_ENABLED=false`), and keeps a separate section for the platforms where the entrypoint genuinely does run.

## Deliberately not touched

- **The `PRE_DEPLOY` job.** Deploy-config change, real blast radius, not ours to make.
- **`documentation/planning/system-review_2026-07/*`** (2 hits) — historical planning records proposing the entrypoint approach. They describe a past decision, not current state; rewriting them would falsify the record.
- **`documentation/archive/**`** (2 hits) — same reasoning, explicitly archived.
- **A dev-password literal at `documentation/production-database-setup.md:126`.** Unrelated to this claim, so not bundled. It is a local-Docker placeholder (`db:5432`, compose-internal), not a live credential — flagged separately.

## Verification

| Gate | Result |
|---|---|
| `pytest` | **2160 passed, 1 skipped**, rc=0 |
| `ruff check .` (blocking) | **All checks passed**, rc=0 — ruff 0.16.1, the pinned version |
| `scripts/check-migration-chain.py` (blocking) | rc=0 — 22 migrations, single head, no duplicates |
| `sh -n scripts/docker-entrypoint.sh` | rc=0 |
| `black --check shuffify/` (non-blocking) | 54 files — **identical on `main` and on this branch**, so entirely pre-existing drift; this PR adds none |

The entrypoint script is executed directly by `tests/test_db_schema_guard.py`; those 5 tests pass, so the added banner does not disturb its contract.

Branched off `6710b49` (current `main`); two-dot and three-dot diffs are identical, so there is no stale-base cargo.
